### PR TITLE
Fix ordering issue where Junit4-style tests conflict

### DIFF
--- a/api/src/main/java/com/force/formula/FormulaEngine.java
+++ b/api/src/main/java/com/force/formula/FormulaEngine.java
@@ -91,7 +91,8 @@ public class FormulaEngine {
         } catch (ClassNotFoundException e1) {
         	boolean isInTest = false;
 			for (StackTraceElement element : Thread.currentThread().getStackTrace()) {
-				if (element.getClassName().startsWith("junit.framework.")) {
+				if (element.getClassName().startsWith("junit.framework.") ||
+						element.getClassName().startsWith("org.junit.")) {
 					isInTest = true;
 					break;
 				}

--- a/api/src/test/java/com/force/formula/DefaultFormulaHooksTest.java
+++ b/api/src/test/java/com/force/formula/DefaultFormulaHooksTest.java
@@ -3,26 +3,22 @@
  */
 package com.force.formula;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
-
 import java.util.Calendar;
 import java.util.Locale;
-
-import org.junit.Test;
 
 import com.force.formula.util.FormulaFieldReferenceImpl;
 import com.force.formula.util.SystemFormulaContext;
 import com.force.i18n.grammar.GrammaticalLocalizer;
+
+import junit.framework.TestCase;
 
 /**
  * Validate and the default implementation for FormulaEngineHooks
  *
  * @author stamm
  */
-public class DefaultFormulaHooksTest  {
+public class DefaultFormulaHooksTest extends TestCase {
 
-	@Test
     public void testEngineHooks() {
         FormulaEngineHooks def = new FormulaEngineHooks() {};
         Calendar cal = Calendar.getInstance();
@@ -52,7 +48,6 @@ public class DefaultFormulaHooksTest  {
     }
     
     
-	@Test
 	public void testGetFieldReferenceValue() {
         FormulaEngineHooks def = new FormulaEngineHooks() {
 			@Override

--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -42,7 +42,7 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
             boolean isCheckingSqlLengthLimit = (isCreateOrEditFormula && !FormulaValidationHooks.get().parseHook_ignoreSqlTextLengthLimit());
             this.context.setProperty(FormulaContext.CHECK_SQL_LENGTH_LIMIT, isCheckingSqlLengthLimit);
             this.context.setProperty(FormulaContext.IS_CREATE_OR_EDIT_FORMULA, isCreateOrEditFormula);
-            this.context.setProperty(FormulaContext.FORCE_DISABLED, isCreateOrEditFormula);
+            this.context.setProperty(FormulaContext.FORCE_DISABLED, forceDisabled);
             
             // Propagating the info if FormulaInfo is being created for Runtime/Design time.
             this.properties.setExistingFormula(existingFormula);


### PR DESCRIPTION
The test runner doesn't necessarily include junit.framework, so test for
  both org.junit. and junit.framework.
Make DefaultFormulaHooksTest a TestCase extension to be doubly sure.
Also fix a typo in BaseFormulaInfoImpl where forceDisabled was set incorrectly