### PR TITLE
Don't allow references to throws Exception

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ buildNumber.properties
 .vscode/
 */.classpath
 */.project
-*/.settings
+**/.settings
 .settings/*
 .metadata
 bin/

--- a/api/src/main/java/com/force/formula/Formula.java
+++ b/api/src/main/java/com/force/formula/Formula.java
@@ -21,9 +21,9 @@ public interface Formula extends Comparable<Formula>, Serializable {
      * @param context
      *            data source for field references
      * @return result of executing the formula
-     * @throws Exception if an error occurred.  TODO: Make this narrower  
+     * @throws FormulaException if an error occurred.  
      */
-    Object evaluate(FormulaRuntimeContext context) throws Exception;
+    Object evaluate(FormulaRuntimeContext context) throws FormulaException;
 
     /**
      * Execute the formula based on field data retrieved from the provided context. Does no final processing of the
@@ -32,18 +32,18 @@ public interface Formula extends Comparable<Formula>, Serializable {
      * @param context
      *            data source for field references
      * @return result of executing the formula
-     * @throws Exception if an error occurred.  TODO: Make this narrower  
+     * @throws FormulaException if an error occurred. 
      */
-    Object evaluateRaw(FormulaRuntimeContext context) throws Exception;
+    Object evaluateRaw(FormulaRuntimeContext context) throws FormulaException;
 
     /**
      * Use this hook to perform bulk processing before the formulas are evaluated. Useful for formula functions like
      * vlookup that perform a query for all contexts and cache the value for runtime evaluation.
      *
      * @param contexts the set of runtime contexts that will be used in execution
-     * @throws Exception if an error occurred.  TODO: Make this narrower  
+     * @throws FormulaException if a FormulaException occurred. 
      */
-    void bulkProcessingBeforeEvaluation(List<FormulaRuntimeContext> contexts) throws Exception;
+    void bulkProcessingBeforeEvaluation(List<FormulaRuntimeContext> contexts) throws FormulaException;
 
     /**
      * Checks whether this formula is simply a direct reference to another field, and if so, returns the field path to

--- a/api/src/main/java/com/force/formula/FormulaCommand.java
+++ b/api/src/main/java/com/force/formula/FormulaCommand.java
@@ -20,7 +20,7 @@ import com.force.formula.sql.ITableAliasRegistry;
 public interface FormulaCommand extends Serializable {
 
     String getName();
-    void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception;
+    void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException;
     boolean isDeterministic(FormulaContext formulaContext);
     boolean isStale(FormulaContext formulaContext);
     default boolean hasAIPredictionFieldReference(FormulaContext formulaContext) {
@@ -47,9 +47,9 @@ public interface FormulaCommand extends Serializable {
      * the value for runtime evaluation.
      *
      * @param contexts the context that provide the values for bulk execution.
-     * @throws Exception if an error occurs: TODO narrow this
+     * @throws FormulaException if a formula exception occurs. (FormulaEvaluationException may also be thrown)
      */
-    void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws Exception;
+    void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws FormulaException;
 
     /**
      * Check that all merge field referenced directly (in the formula itself) or indirectly (via

--- a/api/src/main/java/com/force/formula/GenericFormulaException.java
+++ b/api/src/main/java/com/force/formula/GenericFormulaException.java
@@ -16,4 +16,8 @@ public class GenericFormulaException extends FormulaException {
     public GenericFormulaException(String message) {
         super(message);
     }
+    
+    public GenericFormulaException(Throwable t) {
+        super(t);
+    }
 }

--- a/api/src/main/java/com/force/formula/sql/InvalidFormula.java
+++ b/api/src/main/java/com/force/formula/sql/InvalidFormula.java
@@ -21,12 +21,12 @@ public class InvalidFormula implements FormulaWithSql {
     }
 
     @Override
-    public Object evaluate(FormulaRuntimeContext context) throws Exception {
+    public Object evaluate(FormulaRuntimeContext context) throws FormulaException {
         throw cause;
     }
 
     @Override
-    public Object evaluateRaw(FormulaRuntimeContext context) throws Exception {
+    public Object evaluateRaw(FormulaRuntimeContext context) throws FormulaException {
         throw cause;
     }
 

--- a/impl/src/main/java/com/force/formula/commands/AbstractFormulaCommand.java
+++ b/impl/src/main/java/com/force/formula/commands/AbstractFormulaCommand.java
@@ -55,7 +55,7 @@ public abstract class AbstractFormulaCommand implements FormulaCommand {
     }
 
     @Override
-    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws Exception {
+    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws FormulaException {
     }
 
     @Override

--- a/impl/src/main/java/com/force/formula/commands/BaseFieldReferenceCommand.java
+++ b/impl/src/main/java/com/force/formula/commands/BaseFieldReferenceCommand.java
@@ -38,7 +38,7 @@ public abstract class BaseFieldReferenceCommand extends AbstractFormulaCommand {
         return this.dataType;
     }
 
-    public Object execute(FormulaRuntimeContext context, FormulaFieldReference fieldReference) throws Exception {
+    public Object execute(FormulaRuntimeContext context, FormulaFieldReference fieldReference) throws FormulaException {
         // If this is flagged as the root reference node, then we return a fieldReference.
         // This flag is set only for root nodes, and only when compiled as a reference formula.
         if (isRoot) {

--- a/impl/src/main/java/com/force/formula/commands/CompositeCommand.java
+++ b/impl/src/main/java/com/force/formula/commands/CompositeCommand.java
@@ -9,7 +9,8 @@ import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import com.force.formula.*;
-import com.force.formula.impl.*;
+import com.force.formula.impl.FormulaContextSwitcher;
+import com.force.formula.impl.FormulaValidationHooks;
 import com.force.formula.sql.ITableAliasRegistry;
 import com.force.formula.util.BaseCompositeFormulaContext;
 
@@ -38,7 +39,7 @@ public class CompositeCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         ContextualFormulaFieldInfo fieldInfo = FieldReferenceCommandInfo.lookup(context, fieldName, false);
         boolean shouldFollowFls = context.getGlobalProperties().getFormulaType().isTemplate()
                 && !context.getGlobalProperties().shouldIgnoreFls();
@@ -152,7 +153,7 @@ public class CompositeCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws Exception {
+    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws FormulaException {
         FormulaContextSwitcher switcher = new FormulaContextSwitcher(contexts);
 
         switcher.switchFormulaContext(FieldReferenceCommandInfo.lookup(contexts.get(0), fieldName, false));

--- a/impl/src/main/java/com/force/formula/commands/ConstantFalse.java
+++ b/impl/src/main/java/com/force/formula/commands/ConstantFalse.java
@@ -41,7 +41,7 @@ class ConstantFalseCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(Boolean.FALSE);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/ConstantNullCommand.java
+++ b/impl/src/main/java/com/force/formula/commands/ConstantNullCommand.java
@@ -17,7 +17,7 @@ public class ConstantNullCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(null);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/ConstantTrue.java
+++ b/impl/src/main/java/com/force/formula/commands/ConstantTrue.java
@@ -41,7 +41,7 @@ class ConstantTrueCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(Boolean.TRUE);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/ConvertCurrencyToNumberCommandInfo.java
+++ b/impl/src/main/java/com/force/formula/commands/ConvertCurrencyToNumberCommandInfo.java
@@ -48,7 +48,7 @@ class ConvertCurrencyToNumberCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         FormulaCurrencyData value = checkCurrencyDataType(stack.pop());
 
         stack.push((value != null) ? value.getAmount() : null);

--- a/impl/src/main/java/com/force/formula/commands/FieldReferenceCommand.java
+++ b/impl/src/main/java/com/force/formula/commands/FieldReferenceCommand.java
@@ -35,11 +35,11 @@ public class FieldReferenceCommand extends BaseFieldReferenceCommand implements 
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         stack.push(execute(context));
     }
 
-    public Object execute(FormulaRuntimeContext context) throws Exception {
+    public Object execute(FormulaRuntimeContext context) throws FormulaException {
         Object value = execute(context, this);
         // Some formula uses (SFX Email Templates) require a value, else it's an error.
         if (context.getGlobalProperties().shouldThrowOnEmptyFieldValue() && 

--- a/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
@@ -74,7 +74,7 @@ public class FunctionAddMonths extends FormulaCommandInfoImpl implements Formula
     	//private static BigDecimal MONTH_FRACTION = new BigDecimal("365.24").divide(new BigDecimal("12.00"), RoundingMode.HALF_DOWN);
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             BigDecimal months = (BigDecimal) stack.pop();
         	Object input = stack.pop();
             Date d = checkDateType(input);

--- a/impl/src/main/java/com/force/formula/commands/FunctionAnd.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionAnd.java
@@ -7,7 +7,6 @@ import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaTextUtil;
@@ -114,7 +113,7 @@ class OperatorAndCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         Thunk[] args = new Thunk[numArgs];
         for (int i = 0; i < numArgs; i++)
             args[numArgs - i - 1] = (Thunk)stack.pop();

--- a/impl/src/main/java/com/force/formula/commands/FunctionBegins.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionBegins.java
@@ -48,7 +48,7 @@ class FunctionBeginsCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String sub = checkStringType(stack.pop());
         String target = checkStringType(stack.pop());
         if ((sub == null) || (sub == ""))

--- a/impl/src/main/java/com/force/formula/commands/FunctionCase.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionCase.java
@@ -9,11 +9,10 @@ import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-import com.google.common.collect.Lists;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaTextUtil;
+import com.google.common.collect.Lists;
 
 /**
  * Implementation of CASE that relies on some code in BaseIsPicklistVal
@@ -314,7 +313,7 @@ class FunctionCaseCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Object[] args = new Object[numArgs];
         for (int i = 0; i < numArgs; i++) {
             args[numArgs - i - 1] = stack.pop();

--- a/impl/src/main/java/com/force/formula/commands/FunctionContains.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionContains.java
@@ -49,7 +49,7 @@ class FunctionContainsCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String sub = checkStringType(stack.pop());
         String target = checkStringType(stack.pop());
         if ((sub == null) || (sub == ""))

--- a/impl/src/main/java/com/force/formula/commands/FunctionDate.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDate.java
@@ -7,11 +7,10 @@ import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-import com.force.i18n.BaseLocalizer;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
+import com.force.i18n.BaseLocalizer;
 
 /**
  * Describe your class here.
@@ -209,7 +208,7 @@ class FunctionDateCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal day = checkNumberType(stack.pop());
         BigDecimal month = checkNumberType(stack.pop());
         BigDecimal year = checkNumberType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionDay.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDay.java
@@ -1,8 +1,7 @@
 package com.force.formula.commands;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
+import java.util.*;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
@@ -11,8 +10,6 @@ import com.force.formula.impl.*;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.i18n.BaseLocalizer;
-
-import java.util.Deque;
 
 /**
  * Describe your class here.
@@ -58,7 +55,7 @@ class FunctionDayCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Date d = checkDateType(stack.pop());
         if (d == null)
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/FunctionDistance.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDistance.java
@@ -159,7 +159,7 @@ class DistanceCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String unitAbbreviation     = checkStringType(stack.pop());
         FormulaGeolocation secondLocation = checkGeoLocationType(stack.pop());
         FormulaGeolocation firstLocation  = checkGeoLocationType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionFind.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFind.java
@@ -71,7 +71,7 @@ class FunctionFindCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal startPosition = (hasStartPosition) ? checkNumberType(stack.pop()) : BigDecimal.ZERO;
         String value = checkStringType(stack.pop());
         String search = checkStringType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionFormat.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFormat.java
@@ -131,7 +131,7 @@ class FunctionFormatCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         // Pop off all the arguments
         Object[] args = new Object[numNodes - 1];
         for (int i = 1; i < numNodes; i++) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionFormatCurrency.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFormatCurrency.java
@@ -84,7 +84,7 @@ public class FunctionFormatCurrency extends FormulaCommandInfoImpl {
 
 		
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             BigDecimal amt = checkNumberType(stack.pop());
             String isoCode = checkStringType(stack.pop());
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionGeolocation.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionGeolocation.java
@@ -1,7 +1,6 @@
 package com.force.formula.commands;
 
 import java.math.BigDecimal;
-
 import java.util.Deque;
 
 import com.force.formula.*;
@@ -102,7 +101,7 @@ class GeolocationCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Number longitude = checkNumberType(stack.pop());
         Number latitude = checkNumberType(stack.pop());
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionHour.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionHour.java
@@ -2,7 +2,6 @@ package com.force.formula.commands;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
-
 import java.util.Deque;
 
 import com.force.formula.*;
@@ -58,7 +57,7 @@ class FunctionHourCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
        // Date d = checkDateType(stack.pop());
         FormulaTime d = (FormulaTime)stack.pop();  // to da validate
         if (d == null)

--- a/impl/src/main/java/com/force/formula/commands/FunctionIf.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIf.java
@@ -256,7 +256,7 @@ class OperatorIfFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         Thunk elseVal = (Thunk)stack.pop();
         Thunk thenVal = (Thunk)stack.pop();
         Boolean guard = checkBooleanType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionIfs.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIfs.java
@@ -168,7 +168,7 @@ class OperatorIfsFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         Thunk elseVal = (Thunk)stack.pop();
 
         // Evaluate in short-circuit order so pull all the args off the stack first into a Deque

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsChanged.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsChanged.java
@@ -105,7 +105,7 @@ class FunctionIsChangedCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         boolean isChanged = false;
 
         FormulaRuntimeContext originalValuesContext = context.getOriginalValuesContext();

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsClone.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsClone.java
@@ -51,7 +51,7 @@ class FunctionIsCloneCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(context.isClone());
     }
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsNew.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsNew.java
@@ -46,7 +46,7 @@ class FunctionIsNewCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(context.isNew());
     }
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsNull.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsNull.java
@@ -10,10 +10,9 @@ import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.commands.FunctionNullValue.FunctionNullValueFormulaCommand;
 import com.force.formula.impl.*;
-import com.google.common.base.Splitter;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
+import com.google.common.base.Splitter;
 
 /**
  * Describe your class here.
@@ -117,7 +116,7 @@ class OperatorIsNullCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Object arg = stack.pop();
         if (treatAsString)
             stack.push(Boolean.FALSE);

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsPickVal.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsPickVal.java
@@ -7,11 +7,10 @@ import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-import com.force.i18n.commons.text.TextUtil;
-import com.google.common.base.Joiner;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
+import com.force.i18n.commons.text.TextUtil;
+import com.google.common.base.Joiner;
 
 /**
  * Extend this class with the specific implementation of
@@ -161,7 +160,7 @@ class FunctionIsPicklistValueCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String rhs = (String) stack.pop();
         String lhs = (String) stack.pop();
         Boolean useDbValOverride = context.getProperty(FormulaContext.DO_NOT_USE_DB_VALUE_FOR_PICKLIST_EVALUATION);

--- a/impl/src/main/java/com/force/formula/commands/FunctionLeft.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLeft.java
@@ -47,7 +47,7 @@ class FunctionLeftCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal count = checkNumberType(stack.pop());
         String target = checkStringType(stack.pop());
         if (count == null) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionLen.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLen.java
@@ -49,7 +49,7 @@ class FunctionLenCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String arg = checkStringType(stack.pop());
         if ((arg == null) || (arg.equals("")))
             stack.push(BigDecimal.ZERO);

--- a/impl/src/main/java/com/force/formula/commands/FunctionLower.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLower.java
@@ -93,7 +93,7 @@ class FunctionLowerCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String localeStr = hasLocale ? checkStringType(stack.pop()) : null;
         String target = checkStringType(stack.pop());
         if ((target == null) || (target.equals(""))) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionLpad.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLpad.java
@@ -69,7 +69,7 @@ class FunctionLpadCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String padding = hasPadStr ? checkStringType(stack.pop()) : " ";
         BigDecimal bdCount = checkNumberType(stack.pop());
         String target = checkStringType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionMax.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMax.java
@@ -72,7 +72,7 @@ class FunctionMaxCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal result = checkNumberType(stack.pop());
         if (result == null) {
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/FunctionMid.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMid.java
@@ -49,7 +49,7 @@ class FunctionMidCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal count = checkNumberType(stack.pop());
         BigDecimal start = checkNumberType(stack.pop());
         String target = checkStringType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
@@ -2,6 +2,7 @@ package com.force.formula.commands;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
+import java.util.Deque;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
@@ -10,8 +11,6 @@ import com.force.formula.impl.*;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.i18n.BaseLocalizer;
-
-import java.util.Deque;
 
 /**
  * Describe your class here.
@@ -55,7 +54,7 @@ class FunctionMillisecondCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
        // Date d = checkDateType(stack.pop());
         FormulaTime d = (FormulaTime)stack.pop();  // to da validate
         if (d == null)

--- a/impl/src/main/java/com/force/formula/commands/FunctionMin.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMin.java
@@ -74,7 +74,7 @@ class FunctionMinCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal result = checkNumberType(stack.pop());
         if (result == null) {
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/FunctionMinute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMinute.java
@@ -2,7 +2,6 @@ package com.force.formula.commands;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
-
 import java.util.Deque;
 
 import com.force.formula.*;
@@ -59,7 +58,7 @@ class FunctionMinuteCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
        // Date d = checkDateType(stack.pop());
         FormulaTime d = (FormulaTime)stack.pop();  // to da validate
         if (d == null)

--- a/impl/src/main/java/com/force/formula/commands/FunctionMonth.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMonth.java
@@ -1,8 +1,7 @@
 package com.force.formula.commands;
 
 import java.math.BigDecimal;
-import java.util.Calendar;
-import java.util.Date;
+import java.util.*;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
@@ -11,8 +10,6 @@ import com.force.formula.impl.*;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.i18n.BaseLocalizer;
-
-import java.util.Deque;
 
 /**
  * Describe your class here.
@@ -57,7 +54,7 @@ class FunctionMonthCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Date d = checkDateType(stack.pop());
         if (d == null)
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/FunctionNow.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionNow.java
@@ -1,9 +1,6 @@
 package com.force.formula.commands;
 
-import java.util.Calendar;
-import java.util.Date;
-
-import java.util.Deque;
+import java.util.*;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
@@ -73,7 +70,7 @@ class FunctionNowCommand extends AbstractFormulaCommand {
     private static final String FUNCTIONNOW_VALUE = "common.formula.commands.FunctionNow.value";
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         FormulaDateTime now = (FormulaDateTime)context.getProperty(FUNCTIONNOW_VALUE);
         if (now == null) {
             now = new FormulaDateTime(new Date());

--- a/impl/src/main/java/com/force/formula/commands/FunctionNullValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionNullValue.java
@@ -2,14 +2,12 @@ package com.force.formula.commands;
 
 
 import java.lang.reflect.Type;
-
 import java.util.Deque;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -127,7 +125,7 @@ public class FunctionNullValue extends FormulaCommandInfoImpl implements Formula
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             Object otherVal = stack.pop();
             Object normalVal = stack.pop();
             if (treatAsString) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionOr.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionOr.java
@@ -1,15 +1,13 @@
 package com.force.formula.commands;
 
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.stream.Collectors;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-
-import java.util.Deque;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -142,7 +140,7 @@ class OperatorOrCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         Thunk[] args = new Thunk[numArgs];
         for (int i = 0; i < numArgs; i++)
             args[numArgs - i - 1] = (Thunk) stack.pop();

--- a/impl/src/main/java/com/force/formula/commands/FunctionPriorValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionPriorValue.java
@@ -101,7 +101,7 @@ class FunctionPriorValueCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         stack.pop(); // Throw away the current field value
 
         FormulaRuntimeContext originalValuesContext = context.getOriginalValuesContext();

--- a/impl/src/main/java/com/force/formula/commands/FunctionRight.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionRight.java
@@ -49,7 +49,7 @@ class FunctionRightCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         BigDecimal count = checkNumberType(stack.pop());
         String target = checkStringType(stack.pop());
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionRpad.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionRpad.java
@@ -60,7 +60,7 @@ class FunctionRpadCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String padding = hasPadStr ? checkStringType(stack.pop()) : " ";
         BigDecimal bdCount = checkNumberType(stack.pop());
         String target = checkStringType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionSecond.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionSecond.java
@@ -2,7 +2,6 @@ package com.force.formula.commands;
 
 import java.math.BigDecimal;
 import java.util.Calendar;
-
 import java.util.Deque;
 
 import com.force.formula.*;
@@ -56,7 +55,7 @@ class FunctionSecondCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
        // Date d = checkDateType(stack.pop());
         FormulaTime d = (FormulaTime)stack.pop();  // to da validate
         if (d == null)

--- a/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
@@ -48,7 +48,7 @@ class FunctionSubstituteCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String newText = checkStringType(stack.pop());
         String oldText = checkStringType(stack.pop());
         String sourceText = checkStringType(stack.pop());

--- a/impl/src/main/java/com/force/formula/commands/FunctionText.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionText.java
@@ -221,7 +221,7 @@ class OperatorTextFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws Exception {
+    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws FormulaException {
         try {
             FormulaEngine.getHooks().hook_pushFullAccessRights();
             if (picklistFieldName == null)

--- a/impl/src/main/java/com/force/formula/commands/FunctionTimeNow.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionTimeNow.java
@@ -1,9 +1,6 @@
 package com.force.formula.commands;
 
-import java.util.Calendar;
-import java.util.GregorianCalendar;
-
-import java.util.Deque;
+import java.util.*;
 
 import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
@@ -59,7 +56,7 @@ class FunctionTimeNowCommand extends AbstractFormulaCommand {
     private static final String FUNCTIONTIMENOW_VALUE = "common.formula.commands.FunctionTimeNow.value";
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         FormulaTime now = (FormulaTime)context.getProperty(FUNCTIONTIMENOW_VALUE);
         if (now == null) {
             Calendar cal = new GregorianCalendar(BaseLocalizer.GMT_TZ);

--- a/impl/src/main/java/com/force/formula/commands/FunctionToday.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionToday.java
@@ -69,7 +69,7 @@ class FunctionTodayCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(FormulaDateUtil.todayGmt());
     }
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionTrim.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionTrim.java
@@ -47,7 +47,7 @@ class FunctionTrimCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String arg = checkStringType(stack.pop());
         if ((arg == null) || (arg.equals("")))
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/FunctionUpper.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionUpper.java
@@ -97,7 +97,7 @@ class FunctionUpperCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String localeStr = hasLocale ? checkStringType(stack.pop()) : null;
         String target = checkStringType(stack.pop());
         if ((target == null) || (target.equals(""))) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionWeekday.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionWeekday.java
@@ -54,7 +54,7 @@ public class FunctionWeekday extends FormulaCommandInfoImpl {
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             Date d = checkDateType(stack.pop());
             Object result;
             if (d == null) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionYear.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionYear.java
@@ -54,7 +54,7 @@ class FunctionYearCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Date d = checkDateType(stack.pop());
         if (d == null)
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/commands/OperatorAddOrSubtract.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorAddOrSubtract.java
@@ -350,7 +350,7 @@ class OperatorAddOrSubtractFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Object rhs = stack.pop();
 
         // Unary math

--- a/impl/src/main/java/com/force/formula/commands/OperatorComparison.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorComparison.java
@@ -110,7 +110,7 @@ class OperatorComparisonFormulaCommand extends AbstractFormulaCommand {
 
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Comparable<Object> rhs = checkComparableType(stack.pop());
         Comparable<Object> lhs = checkComparableType(stack.pop());
 

--- a/impl/src/main/java/com/force/formula/commands/OperatorConcat.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorConcat.java
@@ -50,7 +50,7 @@ class OperatorConcatCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         String rhs = checkStringType(stack.pop());
         String lhs = checkStringType(stack.pop());
         if (lhs == null)

--- a/impl/src/main/java/com/force/formula/commands/OperatorEquality.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorEquality.java
@@ -9,7 +9,6 @@ import com.force.formula.*;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.impl.*;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -305,7 +304,7 @@ class OperatorEqualityFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Object rhs = stack.pop();
         Object lhs = stack.pop();
         boolean asString = treatAsString != null ? treatAsString

--- a/impl/src/main/java/com/force/formula/commands/OperatorNot.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorNot.java
@@ -50,7 +50,7 @@ class OperatorNotFormulaCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         Boolean arg = checkBooleanType(stack.pop());
         if (arg == null)
             stack.push(null);

--- a/impl/src/main/java/com/force/formula/impl/FormulaExceptionListener.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaExceptionListener.java
@@ -4,12 +4,14 @@
 
 package com.force.formula.impl;
 
+import com.force.formula.FormulaException;
+
 /**
  * @author dchasman
  * @since 146
  */
-public interface FormulaExceptionListerner {
+public interface FormulaExceptionListener {
 
-    String onException(Exception x) throws Exception;
+    String onException(Exception x) throws FormulaException;
 
 }

--- a/impl/src/main/java/com/force/formula/impl/FormulaImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaImpl.java
@@ -103,7 +103,7 @@ public class FormulaImpl implements FormulaWithSql {
     }
 
     @Override
-    public Object evaluate(FormulaRuntimeContext context) throws Exception {
+    public Object evaluate(FormulaRuntimeContext context) throws FormulaException {
         assert commands != null;
         return FormulaI18nUtils.formatResult(context, context.getFormulaReturnType(), evaluateRaw(context));
     }
@@ -113,7 +113,7 @@ public class FormulaImpl implements FormulaWithSql {
      * fields.
      */
     @Override
-    public Object evaluateRaw(FormulaRuntimeContext context) throws Exception {
+    public Object evaluateRaw(FormulaRuntimeContext context) throws FormulaException {
         long runtimeInitial = System.currentTimeMillis();
         Exception thrownException = null;
         Object result = null;
@@ -144,7 +144,7 @@ public class FormulaImpl implements FormulaWithSql {
 
 
     @Override
-    public void bulkProcessingBeforeEvaluation(List<FormulaRuntimeContext> contexts) throws Exception {
+    public void bulkProcessingBeforeEvaluation(List<FormulaRuntimeContext> contexts) throws FormulaException {
         for (FormulaCommand command : commands) {
             command.preExecuteInBulk(contexts);
         }

--- a/impl/src/main/java/com/force/formula/impl/FormulaUtils.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaUtils.java
@@ -659,21 +659,21 @@ public class FormulaUtils {
         return new TreeSet<String>(visitor.getRefValues().keySet());
     }
 
-    public static void compareFormulaASTs(FormulaAST ast1, FormulaAST ast2) throws Exception {
+    public static void compareFormulaASTs(FormulaAST ast1, FormulaAST ast2) throws GenericFormulaException {
         compareFormulaASTs(ast1, ast2, true);
     }
 
-        public static void compareFormulaASTs(FormulaAST ast1, FormulaAST ast2, boolean compareTokens) throws Exception {
+    public static void compareFormulaASTs(FormulaAST ast1, FormulaAST ast2, boolean compareTokens) throws GenericFormulaException {
         if(ast1 == null && ast2 == null) {
             return;
         }
 
         if(ast1 == null) {
-            throw new Exception("ast1 is null while ast2 is not null");
+            throw new GenericFormulaException("ast1 is null while ast2 is not null");
         }
 
         if(ast2 == null) {
-            throw new Exception("ast2 is null while ast1 is not null");
+            throw new GenericFormulaException("ast2 is null while ast1 is not null");
         }
 
         if(compareTokens) {
@@ -682,81 +682,81 @@ public class FormulaUtils {
 
         //compare public methods
         if(!ast1.getText().equals(ast2.getText())) {
-            throw new Exception("ASTs' texts do not match: " + ast1.getText() + " != " + ast2.getText());
+            throw new GenericFormulaException("ASTs' texts do not match: " + ast1.getText() + " != " + ast2.getText());
         }
 
         if(ast1.getType() != ast2.getType()) {
-            throw new Exception("ASTs' types do not match: " + ast1.getText() + " != " + ast2.getText());
+            throw new GenericFormulaException("ASTs' types do not match: " + ast1.getText() + " != " + ast2.getText());
         }
 
         if(ast1.getLine() != ast2.getLine()) {
-            throw new Exception("ASTs' lines do not match: " + ast1.getLine() + " != " + ast2.getLine());
+            throw new GenericFormulaException("ASTs' lines do not match: " + ast1.getLine() + " != " + ast2.getLine());
         }
 
         if(ast1.getColumn() != ast2.getColumn()) {
-            throw new Exception("ASTs' columns do not match: " + ast1.getColumn() + " != " + ast2.getColumn());
+            throw new GenericFormulaException("ASTs' columns do not match: " + ast1.getColumn() + " != " + ast2.getColumn());
         }
 
         if(ast1.getDataType() != ast2.getDataType()) {
-            throw new Exception("ASTs' data types do not match: " + ast1.getDataType() + " != " + ast2.getDataType());
+            throw new GenericFormulaException("ASTs' data types do not match: " + ast1.getDataType() + " != " + ast2.getDataType());
         }
 
         if(ast1.getColumnType() != ast2.getColumnType()) {
-            throw new Exception("ASTs' column types do not match: " + ast1.getColumnType() + " != " + ast2.getColumnType());
+            throw new GenericFormulaException("ASTs' column types do not match: " + ast1.getColumnType() + " != " + ast2.getColumnType());
         }
 
         if(ast1.isConstantExpression() != ast2.isConstantExpression()) {
-            throw new Exception("ASTs' isConstantExpressions do not match: " + ast1.isConstantExpression() + " != " + ast2.isConstantExpression());
+            throw new GenericFormulaException("ASTs' isConstantExpressions do not match: " + ast1.isConstantExpression() + " != " + ast2.isConstantExpression());
         }
 
         if(ast1.isDynamicReferenceBase() != ast2.isDynamicReferenceBase()) {
-            throw new Exception("ASTs' isDynamicReferenceBases do not match: " + ast1.isDynamicReferenceBase() + " != " + ast2.isDynamicReferenceBase());
+            throw new GenericFormulaException("ASTs' isDynamicReferenceBases do not match: " + ast1.isDynamicReferenceBase() + " != " + ast2.isDynamicReferenceBase());
         }
 
         if(ast1.isLiteral() != ast2.isLiteral()) {
-            throw new Exception("ASTs' isLiterals do not match: " + ast1.isLiteral() + " != " + ast2.isLiteral());
+            throw new GenericFormulaException("ASTs' isLiterals do not match: " + ast1.isLiteral() + " != " + ast2.isLiteral());
         }
 
         if(ast1.getNumberOfChildren() != ast2.getNumberOfChildren()) {
-            throw new Exception("ASTs' number of children do not match: " + ast1.getNumberOfChildren() + " != " + ast2.getNumberOfChildren());
+            throw new GenericFormulaException("ASTs' number of children do not match: " + ast1.getNumberOfChildren() + " != " + ast2.getNumberOfChildren());
         }
 
         compareFormulaASTs((FormulaAST) ast1.getFirstChild(), (FormulaAST) ast2.getFirstChild(), compareTokens);
         compareFormulaASTs((FormulaAST) ast1.getNextSibling(), (FormulaAST) ast2.getNextSibling(), compareTokens);
     }
 
-    public static void compareTokens(antlr.Token t1, antlr.Token t2) throws Exception {
+    public static void compareTokens(antlr.Token t1, antlr.Token t2) throws GenericFormulaException {
         if(t1 == null && t2 == null) {
             return;
         }
 
         if(t1 == null && t2 != null) {
-            throw new Exception("ast1's token is null while ast2's token is not null");
+            throw new GenericFormulaException("ast1's token is null while ast2's token is not null");
         }
 
         if(t1 != null && t2 == null) {
-            throw new Exception("ast2's token is null while ast1's token is not null");
+            throw new GenericFormulaException("ast2's token is null while ast1's token is not null");
         }
 
         //compare public methods
         if(!t1.getText().equals(t2.getText())) {
-            throw new Exception("ASTs' tokens' texts do not match: " + t1.getText() + " != " + t2.getText());
+            throw new GenericFormulaException("ASTs' tokens' texts do not match: " + t1.getText() + " != " + t2.getText());
         }
 
         if(t1.getType() != t2.getType()) {
-            throw new Exception("ASTs' tokens' types do not match: " + t1.getType() + " != " + t2.getType());
+            throw new GenericFormulaException("ASTs' tokens' types do not match: " + t1.getType() + " != " + t2.getType());
         }
 
         if(t1.getLine() != t2.getLine()) {
-            throw new Exception("ASTs' tokens' lines do not match: " + t1.getLine() + " != " + t2.getLine());
+            throw new GenericFormulaException("ASTs' tokens' lines do not match: " + t1.getLine() + " != " + t2.getLine());
         }
 
         if(t1.getColumn() != t2.getColumn()) {
-            throw new Exception("ASTs' tokens' columns do not match: " + t1.getColumn() + " != " + t2.getColumn());
+            throw new GenericFormulaException("ASTs' tokens' columns do not match: " + t1.getColumn() + " != " + t2.getColumn());
         }
 
         if(t1.getFilename() != t2.getFilename()) {
-            throw new Exception("ASTs' tokens' filenames do not match: " + t1.getFilename() + " != " + t2.getFilename());
+            throw new GenericFormulaException("ASTs' tokens' filenames do not match: " + t1.getFilename() + " != " + t2.getFilename());
         }
     }
 }

--- a/impl/src/main/java/com/force/formula/impl/Thunk.java
+++ b/impl/src/main/java/com/force/formula/impl/Thunk.java
@@ -24,7 +24,7 @@ public class Thunk extends AbstractFormulaCommand {
 
     // Pushes itself on the stack for later execution
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(this);
     }
 
@@ -36,14 +36,14 @@ public class Thunk extends AbstractFormulaCommand {
     }
 
     // Really executes the commands
-    public void executeReally(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void executeReally(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         for (FormulaCommand command : commands) {
             command.execute(context, stack);
         }
     }
 
     @Override
-    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws Exception {
+    public void preExecuteInBulk(List<FormulaRuntimeContext> contexts) throws FormulaException {
         for (FormulaCommand command : commands) {
             command.preExecuteInBulk(contexts);
         }

--- a/impl/src/main/java/com/force/formula/template/commands/DynamicFieldSelector.java
+++ b/impl/src/main/java/com/force/formula/template/commands/DynamicFieldSelector.java
@@ -51,7 +51,7 @@ class DynamicFieldSelectorCommand extends AbstractFormulaCommand {
 
     // The name is the value.
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         stack.push(fieldName);
     }
 

--- a/impl/src/main/java/com/force/formula/template/commands/DynamicReference.java
+++ b/impl/src/main/java/com/force/formula/template/commands/DynamicReference.java
@@ -86,7 +86,7 @@ public class DynamicReference extends FormulaCommandInfoImpl implements FormulaC
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
             Object subscript = stack.pop();
             Object base  = stack.pop();
             if (base == null) {
@@ -96,7 +96,7 @@ public class DynamicReference extends FormulaCommandInfoImpl implements FormulaC
             }
         }
 
-        private Object doSubscript(FormulaRuntimeContext context, Object base, Object subscript) throws Exception {
+        private Object doSubscript(FormulaRuntimeContext context, Object base, Object subscript) throws FormulaException {
             // Map, List, Array, and object are different cases.
             Class<? extends Object> type;
 

--- a/impl/src/main/java/com/force/formula/template/commands/EncodingFunctionBase.java
+++ b/impl/src/main/java/com/force/formula/template/commands/EncodingFunctionBase.java
@@ -57,7 +57,7 @@ public abstract class EncodingFunctionBase extends FormulaCommandInfoImpl implem
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             Object arg = stack.pop();
             arg = (arg == null) ? "" : arg;
             stack.push(encode(checkStringType(arg)));

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionIsNumber.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionIsNumber.java
@@ -67,7 +67,7 @@ public class FunctionIsNumber extends FormulaCommandInfoImpl implements FormulaC
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
             Object input = stack.pop();
             if (input != null && input != ConstantString.NullString) {
                 stack.push(BigDecimalHelper.functionIsNumber(checkStringType(input)));

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionMap.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionMap.java
@@ -1,6 +1,7 @@
 package com.force.formula.template.commands;
 
 import java.lang.reflect.Type;
+import java.util.Deque;
 import java.util.LinkedHashMap;
 
 import com.force.formula.*;
@@ -9,8 +10,6 @@ import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.commands.*;
 import com.force.formula.impl.*;
 import com.force.formula.sql.SQLPair;
-
-import java.util.Deque;
 
 /**
  * @author dchasman
@@ -80,7 +79,7 @@ class FunctionMapCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) {
         FunctionMap.StringToStringMap result = new FunctionMap.StringToStringMap();
 
         // Temporary arrays hold the popped elements so we can push them into the result map

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
@@ -1,6 +1,7 @@
 package com.force.formula.template.commands;
 
 import java.lang.reflect.Type;
+import java.util.Deque;
 import java.util.regex.Pattern;
 
 import com.force.formula.*;
@@ -8,12 +9,9 @@ import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
 import com.force.formula.commands.*;
 import com.force.formula.impl.*;
-import com.force.formula.template.commands.AccessCountedCharSequence.AccessCountExceededException;
-
-import java.util.Deque;
-
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
+import com.force.formula.template.commands.AccessCountedCharSequence.AccessCountExceededException;
 
 @AllowedContext(section=SelectorSection.ADVANCED, changeOnly=true, isJavascript=false)
 public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaCommandValidator {
@@ -79,7 +77,7 @@ public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaComm
         }
 
         @Override
-        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
             Object regex = stack.pop();
             Object input = stack.pop();
             input = (input == null) ? "" : input;

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionTemplate.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionTemplate.java
@@ -64,7 +64,7 @@ class FunctionTemplateCommand extends AbstractFormulaCommand {
     }
 
     @Override
-    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws Exception {
+    public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
         String urlEncoding = FormulaValidationHooks.get().getTemplateUrlEncoding(context);
 
         // Dethunk all of the template() arguments and evaluate each one using its own isolated stack to handle exceptions on a
@@ -114,11 +114,15 @@ class FunctionTemplateCommand extends AbstractFormulaCommand {
         stack.push(result);
     }
 
-    private Object handleException(FormulaRuntimeContext context, Exception x) throws Exception {
-        if (context instanceof FormulaExceptionListerner) {
-            return ((FormulaExceptionListerner)context).onException(x);
+    private Object handleException(FormulaRuntimeContext context, Exception x) throws FormulaException {
+        if (context instanceof FormulaExceptionListener) {
+            return ((FormulaExceptionListener)context).onException(x);
+        } else if (x instanceof FormulaException) {
+            throw (FormulaException) x;
+        } else if (x instanceof RuntimeException) {
+            throw (RuntimeException) x;
         } else {
-            throw x;
+            throw new GenericFormulaException(x);
         }
     }
 }

--- a/pmd-ruleset.xml
+++ b/pmd-ruleset.xml
@@ -42,7 +42,12 @@
     <rule ref="category/java/design.xml/CollapsibleIfStatements" />
     <rule ref="category/java/design.xml/ExceptionAsFlowControl" />  
     <rule ref="category/java/design.xml/UselessOverridingMethod" />
-
+    <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+      <properties>
+        <property name="IgnoreJUnitCompletely" value="true"/>
+      </properties>
+    </rule>
+    
     <rule ref="category/java/errorprone.xml/AvoidBranchingStatementAsLastInLoop" />
     <rule ref="category/java/errorprone.xml/AvoidCatchingNPE" />
     <rule ref="category/java/errorprone.xml/AvoidDecimalLiteralsInBigDecimalConstructor" />

--- a/test-utils/src/main/java/com/force/formula/impl/FormulaTestCaseInfo.java
+++ b/test-utils/src/main/java/com/force/formula/impl/FormulaTestCaseInfo.java
@@ -153,7 +153,7 @@ public class FormulaTestCaseInfo {
     /*
      * This returns only non-formula reference fields
      */
-    public List<FieldDefinitionInfo> getFieldsToCreate() throws Exception {
+    public List<FieldDefinitionInfo> getFieldsToCreate() {
         if (this.testRunnables == null)
             generateRunnables();
         return createList;

--- a/test-utils/src/main/java/com/force/formula/impl/FormulaTestUtils.java
+++ b/test-utils/src/main/java/com/force/formula/impl/FormulaTestUtils.java
@@ -215,7 +215,7 @@ public class FormulaTestUtils {
     }
 
     public List<String> getFormulaNames(String xmlFileName, String retriveForEntity)
-        throws ParserConfigurationException, SAXException, IOException, Exception {
+        throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document formulaFieldsDocument = documentBuilder.parse(new File(xmlFileName));
@@ -251,7 +251,7 @@ public class FormulaTestUtils {
                 }
             }
             catch (Exception e) {
-                throw new Exception("Failed to Parse " + xmlFileName + " for Formula: " + labelName + "\n"
+                throw new RuntimeException("Failed to Parse " + xmlFileName + " for Formula: " + labelName + "\n"
                     + e.getMessage(), e);
             }
         }
@@ -259,7 +259,7 @@ public class FormulaTestUtils {
     }
 
     public List<FieldDefinitionInfo> getFieldDefintions(String xmlFileName, String retriveForEntity)
-        throws ParserConfigurationException, SAXException, IOException, Exception {
+        throws ParserConfigurationException, SAXException, IOException {
         DocumentBuilderFactory documentBuilderFactory = DocumentBuilderFactory.newInstance();
         DocumentBuilder documentBuilder = documentBuilderFactory.newDocumentBuilder();
         Document fieldsDocument = documentBuilder.parse(new File(xmlFileName));


### PR DESCRIPTION
Change a bunch of signatures to throw FormulaException and callers to use
  FormulaEvaluationException for SQL/IOException if necessary instead of 
  overly broad throwing of Exception
Fix a few typos including Listerner
Add a PMD injunction against throws Exception outside of junit
