### PR TITLE
Fix javascript addMonths issue with fractional months

### DIFF
--- a/impl/src/test/goldfiles/FormulaFields/testAddMonths.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testAddMonths.xml
@@ -138,12 +138,12 @@
       <inputvalues>[2004:12:31:11:32:00, -0.50]</inputvalues>
          <formula>Fri Dec 31 11:32:00 GMT 2004</formula>
          <sql>2004-12-31 11:32:00.0</sql>
-         <javascript>Tue Nov 30 11:32:00 GMT 2004</javascript>
-         <javascriptLp>Tue Nov 30 11:32:00 GMT 2004</javascriptLp>
+         <javascript>Fri Dec 31 11:32:00 GMT 2004</javascript>
+         <javascriptLp>Fri Dec 31 11:32:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Fri Dec 31 11:32:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-12-31 11:32:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Tue Nov 30 11:32:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Tue Nov 30 11:32:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Fri Dec 31 11:32:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Fri Dec 31 11:32:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:02:29:07:34:00:GMT, -12.00]</inputvalues>
@@ -259,12 +259,12 @@
       <inputvalues>[2004:02:29:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Sun Feb 29 07:34:00 GMT 2004</formula>
          <sql>2004-02-29 07:34:00.0</sql>
-         <javascript>Sat Jan 31 07:34:00 GMT 2004</javascript>
-         <javascriptLp>Sat Jan 31 07:34:00 GMT 2004</javascriptLp>
+         <javascript>Sun Feb 29 07:34:00 GMT 2004</javascript>
+         <javascriptLp>Sun Feb 29 07:34:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Sun Feb 29 07:34:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-02-29 07:34:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Sat Jan 31 07:34:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Sat Jan 31 07:34:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:29:07:34:00:GMT, -12.00]</inputvalues>
@@ -380,12 +380,12 @@
       <inputvalues>[2004:03:29:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Mon Mar 29 07:34:00 GMT 2004</formula>
          <sql>2004-03-29 07:34:00.0</sql>
-         <javascript>Sun Feb 29 07:34:00 GMT 2004</javascript>
-         <javascriptLp>Sun Feb 29 07:34:00 GMT 2004</javascriptLp>
+         <javascript>Mon Mar 29 07:34:00 GMT 2004</javascript>
+         <javascriptLp>Mon Mar 29 07:34:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Mon Mar 29 07:34:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-03-29 07:34:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Mon Mar 29 07:34:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Mon Mar 29 07:34:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:30:07:34:00:GMT, -12.00]</inputvalues>
@@ -501,12 +501,12 @@
       <inputvalues>[2004:03:30:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Tue Mar 30 07:34:00 GMT 2004</formula>
          <sql>2004-03-30 07:34:00.0</sql>
-         <javascript>Mon Mar 01 07:34:00 GMT 2004</javascript>
-         <javascriptLp>Mon Mar 01 07:34:00 GMT 2004</javascriptLp>
+         <javascript>Tue Mar 30 07:34:00 GMT 2004</javascript>
+         <javascriptLp>Tue Mar 30 07:34:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Tue Mar 30 07:34:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-03-30 07:34:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Mon Mar 01 07:34:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Mon Mar 01 07:34:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Tue Mar 30 07:34:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Tue Mar 30 07:34:00 GMT 2004</javascriptLpNullAsNull>
       </result>
    </testInstance>
 </testCase>

--- a/impl/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
@@ -135,16 +135,15 @@
          <javascriptLpNullAsNull>Fri Dec 31 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
-      <!-- Test Case results don't match: viaFormula Fri Dec 31 00:00:00 GMT 2004 does not equal viaJavascript Tue Nov 30 00:00:00 GMT 2004 -->
       <inputvalues>[2004:12:31:11:32:00, -0.50]</inputvalues>
          <formula>Fri Dec 31 00:00:00 GMT 2004</formula>
          <sql>2004-12-31 00:00:00.0</sql>
-         <javascript>Tue Nov 30 00:00:00 GMT 2004</javascript>
-         <javascriptLp>Tue Nov 30 00:00:00 GMT 2004</javascriptLp>
+         <javascript>Fri Dec 31 00:00:00 GMT 2004</javascript>
+         <javascriptLp>Fri Dec 31 00:00:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Fri Dec 31 00:00:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-12-31 00:00:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Tue Nov 30 00:00:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Tue Nov 30 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Fri Dec 31 00:00:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Fri Dec 31 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:02:29:07:34:00:GMT, -12.00]</inputvalues>
@@ -257,16 +256,15 @@
          <javascriptLpNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
-      <!-- Test Case results don't match: viaFormula Sun Feb 29 00:00:00 GMT 2004 does not equal viaJavascript Sat Jan 31 00:00:00 GMT 2004 -->
       <inputvalues>[2004:02:29:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Sun Feb 29 00:00:00 GMT 2004</formula>
          <sql>2004-02-29 00:00:00.0</sql>
-         <javascript>Sat Jan 31 00:00:00 GMT 2004</javascript>
-         <javascriptLp>Sat Jan 31 00:00:00 GMT 2004</javascriptLp>
+         <javascript>Sun Feb 29 00:00:00 GMT 2004</javascript>
+         <javascriptLp>Sun Feb 29 00:00:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Sun Feb 29 00:00:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-02-29 00:00:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Sat Jan 31 00:00:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Sat Jan 31 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:29:07:34:00:GMT, -12.00]</inputvalues>
@@ -380,16 +378,15 @@
          <javascriptLpNullAsNull>Mon Mar 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
-      <!-- Test Case results don't match: viaFormula Mon Mar 29 00:00:00 GMT 2004 does not equal viaJavascript Sun Feb 29 00:00:00 GMT 2004 -->
       <inputvalues>[2004:03:29:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Mon Mar 29 00:00:00 GMT 2004</formula>
          <sql>2004-03-29 00:00:00.0</sql>
-         <javascript>Sun Feb 29 00:00:00 GMT 2004</javascript>
-         <javascriptLp>Sun Feb 29 00:00:00 GMT 2004</javascriptLp>
+         <javascript>Mon Mar 29 00:00:00 GMT 2004</javascript>
+         <javascriptLp>Mon Mar 29 00:00:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Mon Mar 29 00:00:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-03-29 00:00:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Mon Mar 29 00:00:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Mon Mar 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:30:07:34:00:GMT, -12.00]</inputvalues>
@@ -505,16 +502,15 @@
          <javascriptLpNullAsNull>Tue Mar 30 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
-      <!-- Test Case results don't match: viaFormula Tue Mar 30 00:00:00 GMT 2004 does not equal viaJavascript Mon Mar 01 00:00:00 GMT 2004 -->
       <inputvalues>[2004:03:30:07:34:00:GMT, -0.50]</inputvalues>
          <formula>Tue Mar 30 00:00:00 GMT 2004</formula>
          <sql>2004-03-30 00:00:00.0</sql>
-         <javascript>Mon Mar 01 00:00:00 GMT 2004</javascript>
-         <javascriptLp>Mon Mar 01 00:00:00 GMT 2004</javascriptLp>
+         <javascript>Tue Mar 30 00:00:00 GMT 2004</javascript>
+         <javascriptLp>Tue Mar 30 00:00:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Tue Mar 30 00:00:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-03-30 00:00:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Mon Mar 01 00:00:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Mon Mar 01 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Tue Mar 30 00:00:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Tue Mar 30 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
    </testInstance>
 </testCase>

--- a/test-utils/src/main/java/com/force/formula/commands/FormulaJsTestUtils.java
+++ b/test-utils/src/main/java/com/force/formula/commands/FormulaJsTestUtils.java
@@ -143,9 +143,9 @@ public class FormulaJsTestUtils {
 
                 // Note, these add months does what java does, but may not do what oracle/postgres does
                 
-                .append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.floor(b));return new Date(d.getTime()-86400000);};");
+                .append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));return new Date(d.getTime()-86400000);};");
                 // Use this if you want to support fractional dates
-        		//.append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.floor(b));d.setUTCDate(d.getUTCDate()+Math.floor((b%1)*365.24/12));return new Date(d.getTime()-86400000);};");
+        		//.append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));d.setUTCDate(d.getUTCDate()+Math.trunc((b%1)*365.24/12));return new Date(d.getTime()-86400000);};");
         return fContext.toString();
     }
 


### PR DESCRIPTION
Use Math.trunc, not round to have negative fractional months work correctly.
  But leap years still differ in javascript.