### PR TITLE
Remove unnecessary String.format in FunctionFind

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FunctionFind.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFind.java
@@ -34,10 +34,10 @@ public class FunctionFind extends FormulaCommandInfoImpl {
         	// With postgres, you need to do a bunch of stuff to get around the lack of a built-in for the offset.
             String startPosition = getSqlHooks(context).sqlNvl() + "(" + args[2] + ", 1)";
 	        String instr = getSqlHooks(context).sqlInstr3(args[1], args[0], "GREATEST("+startPosition+",1)");
-	        sql.append(String.format(getSqlHooks(context).sqlNvl() + "(" + instr + ", 0)", args[1], args[0], startPosition));
+	        sql.append(getSqlHooks(context).sqlNvl() + "(" + instr + ", 0)");
         } else {
         	// Use regular instr if there isn't a position offset
-	        sql.append(String.format(getSqlHooks(context).sqlNvl() + "(" + getSqlHooks(context).sqlInstr2(args[1], args[0]) + ", 0)", args[1], args[0]));
+	        sql.append(getSqlHooks(context).sqlNvl() + "(" + getSqlHooks(context).sqlInstr2(args[1], args[0]) + ", 0)");
         }
 
         String guard = SQLPair.generateGuard(guards, null);

--- a/impl/src/test/goldfiles/FormulaFields/testFindOnText.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testFindOnText.xml
@@ -57,5 +57,16 @@
          <javascriptNullAsNull>0</javascriptNullAsNull>
          <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
+      <result>
+      <inputvalues>[%]</inputvalues>
+         <formula>0</formula>
+         <sql>0.00000000000000000000000000000000</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0.00000000000000000000000000000000</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
+      </result>
    </testInstance>
 </testCase>

--- a/impl/src/test/goldfiles/FormulaFields/testFindOnTextWithIndex.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testFindOnTextWithIndex.xml
@@ -101,5 +101,16 @@
          <javascriptNullAsNull>0</javascriptNullAsNull>
          <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
+      <result>
+      <inputvalues>[%, Foo%Foo, 2]</inputvalues>
+         <formula>4</formula>
+         <sql>4.00000000000000000000000000000000</sql>
+         <javascript>4</javascript>
+         <javascriptLp>4</javascriptLp>
+         <formulaNullAsNull>4</formulaNullAsNull>
+         <sqlNullAsNull>4.00000000000000000000000000000000</sqlNullAsNull>
+         <javascriptNullAsNull>4</javascriptNullAsNull>
+         <javascriptLpNullAsNull>4</javascriptLpNullAsNull>
+      </result>
    </testInstance>
 </testCase>

--- a/impl/src/test/resources/com/force/formula/impl/data/findOnText
+++ b/impl/src/test/resources/com/force/formula/impl/data/findOnText
@@ -2,3 +2,4 @@ Text
 Hello
 ConText
 Context
+%

--- a/impl/src/test/resources/com/force/formula/impl/data/findOnTextWithIndex
+++ b/impl/src/test/resources/com/force/formula/impl/data/findOnTextWithIndex
@@ -6,3 +6,4 @@ Test,FFFFTest,-1
 Test,FFFFTest,5
 Test,FTest,0
 -,ABC - XYZ,10
+%,Foo%Foo,2

--- a/oracle-test/src/test/goldfiles/FormulaFields/testFindOnText.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testFindOnText.xml
@@ -41,5 +41,12 @@
          <formulaNullAsNull>0</formulaNullAsNull>
          <sqlNullAsNull>0</sqlNullAsNull>
       </result>
+      <result>
+      <inputvalues>[%]</inputvalues>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+      </result>
    </testInstance>
 </testCase>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testFindOnTextWithIndex.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testFindOnTextWithIndex.xml
@@ -69,5 +69,12 @@
          <formulaNullAsNull>0</formulaNullAsNull>
          <sqlNullAsNull>0</sqlNullAsNull>
       </result>
+      <result>
+      <inputvalues>[%, Foo%Foo, 2]</inputvalues>
+         <formula>4</formula>
+         <sql>4</sql>
+         <formulaNullAsNull>4</formulaNullAsNull>
+         <sqlNullAsNull>4</sqlNullAsNull>
+      </result>
    </testInstance>
 </testCase>

--- a/oracle-test/src/test/java/com/force/formula/impl/TestOracleExtendedFormulas.java
+++ b/oracle-test/src/test/java/com/force/formula/impl/TestOracleExtendedFormulas.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 import org.xml.sax.SAXException;

--- a/oracle-test/src/test/java/com/force/formula/impl/TestOracleMathFormulas.java
+++ b/oracle-test/src/test/java/com/force/formula/impl/TestOracleMathFormulas.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 import org.xml.sax.SAXException;

--- a/oracle-test/src/test/java/com/force/formula/impl/TestOracleStandardFormulas.java
+++ b/oracle-test/src/test/java/com/force/formula/impl/TestOracleStandardFormulas.java
@@ -10,7 +10,6 @@ import java.io.IOException;
 
 import javax.xml.parsers.ParserConfigurationException;
 
-import org.junit.Ignore;
 import org.junit.runner.RunWith;
 import org.junit.runners.AllTests;
 import org.xml.sax.SAXException;


### PR DESCRIPTION
Don't allow user-provided strings in the format string for String.format
Put in a test for '%' to validate the change
@dgyawali