### PR TITLE
Don't use releases profile which skips staging

### DIFF
--- a/.github/workflows/maven-release.yml
+++ b/.github/workflows/maven-release.yml
@@ -50,7 +50,7 @@ jobs:
     - name: Prepare Release
       id: release
       run: >
-          mvn -V -gs $GITHUB_WORKSPACE/generated-settings/settings.xml -B -P sign-artifacts,db-tests,releases -e release:clean release:prepare && 
+          mvn -V -gs $GITHUB_WORKSPACE/generated-settings/settings.xml -B -P sign-artifacts,db-tests -e release:clean release:prepare && 
           echo "::set-output name=RELEASED_VERSION::$(grep scm.tag= release.properties | cut -d'=' -f2 | cut -c2-)"
       env:
           MAVEN_USERNAME: ${{ secrets.MAVEN_CENTRAL_USER }}


### PR DESCRIPTION
Maven central's getting hammered by log4j and this is the wrong plugin