### PR TITLE
Raise maxSqlLimit to 100000

### DIFF
--- a/api/src/main/java/com/force/formula/FormulaInfo.java
+++ b/api/src/main/java/com/force/formula/FormulaInfo.java
@@ -16,7 +16,7 @@ public interface FormulaInfo<T extends FormulaFieldInfo> {
     static final int MAX_FORMULA_LENGTH = 3900;
     static final int MAX_STORAGE_SIZE = 4000;
     static final int MAX_SQL_SIZE_NEW_FORMULA = 5000;
-    static final int MAX_SQL_SIZE_LIMIT = 8000;
+    static final int MAX_SQL_SIZE_LIMIT = 100000;  // Oracle's limit is 400K on a statement, so 100K should be enough
     static final int MAX_STRING_VALUE_LENGTH = 1300;
     /** The maximum JavaScript size for formulas that generate JS. */
     static final int MAX_JS_SIZE = 5000;

--- a/api/src/test/java/com/force/formula/FormulaPropertiesTest.java
+++ b/api/src/test/java/com/force/formula/FormulaPropertiesTest.java
@@ -1,0 +1,29 @@
+/**
+ * 
+ */
+package com.force.formula;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+
+/**
+ * @author stamm
+ * 0.1.23
+ */
+
+public class FormulaPropertiesTest {
+
+	@Test(expected = IllegalArgumentException.class)
+	public void testMaxSqlSize() {
+		FormulaProperties props = new FormulaProperties();
+		props.setMaxSqlSize(500000);
+	}
+
+	public void testFormulaProps() {
+		FormulaProperties props = new FormulaProperties();
+		props.setMaxSqlSize(15000);
+		Assert.assertEquals(15000, props.getMaxSqlSize());
+	}
+
+}


### PR DESCRIPTION
Add test to validate that 15K is ok, but 500K is not.  
Note: Max oracle size of a statement is 400K.
@dgyawali 