### PR TITLE
Fix Millisecond logic with truncation

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
@@ -40,7 +40,10 @@ public class FunctionMillisecond extends FormulaCommandInfoImpl {
     	FormulaSqlHooks hooks = getSqlHooks(context);
     	if (hooks.isTransactSqlStyle()) {
     		return "DATEPART(MILLISECOND,"+arg+")";
+    	} else if (context.getSqlStyle().isMysqlStyle()) {
+    		return "1000*MICROSECOND("+arg+")";
     	}
+    	
     	String trunc = hooks.sqlTrunc(arg + "/1000");
         return hooks.sqlTrunc("(" + arg + " -"+trunc+" * 1000)");
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMillisecond.java
@@ -42,7 +42,7 @@ public class FunctionMillisecond extends FormulaCommandInfoImpl {
     		return "DATEPART(MILLISECOND,"+arg+")";
     	}
     	String trunc = hooks.sqlTrunc(arg + "/1000");
-        return trunc + "((" + arg + " -"+trunc+" * 1000)) ";
+        return hooks.sqlTrunc("(" + arg + " -"+trunc+" * 1000)");
     }
 
     @Override

--- a/impl/src/main/resources/com/force/formula/formulaLabels.xml
+++ b/impl/src/main/resources/com/force/formula/formulaLabels.xml
@@ -225,6 +225,8 @@
         <param name="BLANKVALUE_DESCR">Checks whether expression is blank and returns substitute_expression if it is blank. If expression is not blank, returns the original expression value.</param>
         <param name="ROUND">ROUND(number,num_digits)</param>
         <param name="ROUND_DESCR">Rounds a number to a specified number of digits</param>
+        <param name="TRUNC">TRUNC(number,num_digits)</param>
+        <param name="TRUNC_DESCR">Truncates a number to a specified number of digits</param>
         <param name="SQRT">SQRT(number)</param>
         <param name="SQRT_DESCR">Returns the positive square root of a number</param>
         <param name="BEGINS">BEGINS(text, compare_text)</param>
@@ -320,6 +322,8 @@
 
         <param name="CHR">CHR(number)</param>
         <param name="CHR_DESCR">Return a string with the first character's code point as the given number.</param>
+        <param name="ASCII">CHR(text)</param>
+        <param name="ASCII_DESCR">Return the first character's code point from the given string as a number.</param>
 
         <param name="FORMATCURRENCY">FORMATCURRENCY(currencyisocode, number)</param>
         <param name="FORMATCURRENCY_DESCR">Format the given number as a current using the scale of the given currency code, with that code prepended.</param>

--- a/impl/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testMillisecWithValidDateTimeString">
+   <testInstance formula="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))" returntype="Double" precision="12" scale="2">
+    <SqlOutput nullAsNull="true">
+       <Sql>TRUNC((NULL -TRUNC(NULL/1000) * 1000))</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>TRUNC((NULL -TRUNC(NULL/1000) * 1000))</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+    <JsOutput highPrec="true" nullAsNull="false">new Date(new Date(&quot;2015-03-17 17:00:00&quot;).setUTCFullYear(1970,0,1)).getMilliseconds()</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">new Date(new Date(&quot;2015-03-17 17:00:00&quot;).setUTCFullYear(1970,0,1)).getMilliseconds()</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="false">new Date(new Date(&quot;2015-03-17 17:00:00&quot;).setUTCFullYear(1970,0,1)).getMilliseconds()</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">new Date(new Date(&quot;2015-03-17 17:00:00&quot;).setUTCFullYear(1970,0,1)).getMilliseconds()</JsOutput>
+      <result>
+      <inputvalues>No data</inputvalues>
+         <formula>Error: java.lang.RuntimeException</formula>
+         <sql>Error: ERROR: function round(double precision, integer) does not exist   Hint: No function matches the given name and argument types. You might need to add explicit type casts.   Position: 37</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>Error: java.lang.RuntimeException</formulaNullAsNull>
+         <sqlNullAsNull>Error: ERROR: function round(double precision, integer) does not exist   Hint: No function matches the given name and argument types. You might need to add explicit type casts.   Position: 37</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/impl/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
@@ -1,39 +1,39 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testCase name="testMillisecondValueWithValidInValid">
-   <testInstance formula="Second(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
+   <testInstance formula="MilliSecond(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
     <SqlOutput nullAsNull="true">
-       <Sql>TRUNC((CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000-TRUNC(CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000/60000) * 60000)/1000)</Sql>
+       <Sql>TRUNC((CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000 -TRUNC(CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000/1000) * 1000))</Sql>
        <Guard> NOT $!s0s!$.dateString__c ~ '^\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01]) ([01]?[0-9]|2[0-3]):[0-5]?\d:[0-5]?\d$' </Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>TRUNC((CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000-TRUNC(CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000/60000) * 60000)/1000)</Sql>
+       <Sql>TRUNC((CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000 -TRUNC(CAST(TO_CHAR(TO_TIMESTAMP($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSS') AS NUMERIC) * 1000/1000) * 1000))</Sql>
        <Guard> NOT $!s0s!$.dateString__c ~ '^\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01]) ([01]?[0-9]|2[0-3]):[0-5]?\d:[0-5]?\d$' </Guard>
     </SqlOutput>
-    <JsOutput highPrec="true" nullAsNull="false">(context.record.dateString__c!=null)?((new $F.Decimal(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getSeconds()))):null</JsOutput>
-    <JsOutput highPrec="true" nullAsNull="true">(context.record.dateString__c!=null)?((new $F.Decimal(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getSeconds()))):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="false">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getSeconds()):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="true">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getSeconds()):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="false">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getMilliseconds()):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getMilliseconds()):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="false">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getMilliseconds()):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(context.record.dateString__c!=null)?(new Date(new Date(context.record.dateString__c + ' GMT').setUTCFullYear(1970,0,1)).getMilliseconds()):null</JsOutput>
       <result>
       <inputvalues>[2011-01-29 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <javascript>9</javascript>
-         <javascriptLp>9</javascriptLp>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
-         <javascriptNullAsNull>9</javascriptNullAsNull>
-         <javascriptLpNullAsNull>9</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-01-9 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <javascript>9</javascript>
-         <javascriptLp>9</javascriptLp>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
-         <javascriptNullAsNull>9</javascriptNullAsNull>
-         <javascriptLpNullAsNull>9</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-1-29 00:00:00]</inputvalues>
@@ -70,25 +70,25 @@
       </result>
       <result>
       <inputvalues>[2011-1-23 2:22:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <javascript>59</javascript>
-         <javascriptLp>59</javascriptLp>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
-         <javascriptNullAsNull>59</javascriptNullAsNull>
-         <javascriptLpNullAsNull>59</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-2-7 5:22:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <javascript>33</javascript>
-         <javascriptLp>33</javascriptLp>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
-         <javascriptNullAsNull>33</javascriptNullAsNull>
-         <javascriptLpNullAsNull>33</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-13-29 00:00:09]</inputvalues>
@@ -147,14 +147,14 @@
       </result>
       <result>
       <inputvalues>[2012-01-01 23:59:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <javascript>59</javascript>
-         <javascriptLp>59</javascriptLp>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
-         <javascriptNullAsNull>59</javascriptNullAsNull>
-         <javascriptLpNullAsNull>59</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-10-34 00:00:00]</inputvalues>
@@ -169,25 +169,25 @@
       </result>
       <result>
       <inputvalues>[2012-02-07 5:2:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <javascript>33</javascript>
-         <javascriptLp>33</javascriptLp>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
-         <javascriptNullAsNull>33</javascriptNullAsNull>
-         <javascriptLpNullAsNull>33</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-02-07 5:22:3]</inputvalues>
-         <formula>3</formula>
-         <sql>3</sql>
-         <javascript>3</javascript>
-         <javascriptLp>3</javascriptLp>
-         <formulaNullAsNull>3</formulaNullAsNull>
-         <sqlNullAsNull>3</sqlNullAsNull>
-         <javascriptNullAsNull>3</javascriptNullAsNull>
-         <javascriptLpNullAsNull>3</javascriptLpNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <javascript>0</javascript>
+         <javascriptLp>0</javascriptLp>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
+         <javascriptNullAsNull>0</javascriptNullAsNull>
+         <javascriptLpNullAsNull>0</javascriptLpNullAsNull>
       </result>
    </testInstance>
 </testCase>

--- a/impl/src/test/resources/com/force/formula/impl/formulatests.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulatests.xml
@@ -132,7 +132,7 @@ author: Srikanth Yendluri/Doug Chasman
      <testcase name="testMillisecondValueWithValidInValid" devName="testMilliecondValueWithValidInValid"
          labelName="testSecondValueWithValidInValid" dataType="Double" eval="formula,template" dataFile="functiondatevalue-dateandtime"
          scale="2" precision="12"  labels="extended"
-         code="Second(TimeValue(DATETIMEVALUE(dateString__c)))">
+         code="MilliSecond(TimeValue(DATETIMEVALUE(dateString__c)))">
          <referencefield devName="dateString" labelName="dateString"
              dataType="Text"  length="50"/>
       </testcase>

--- a/impl/src/test/resources/com/force/formula/impl/formulatests.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulatests.xml
@@ -60,6 +60,12 @@ author: Srikanth Yendluri/Doug Chasman
          scale="2" precision="12"
          code="MilliSecond(TIMEVALUE(&quot;10:40:55.666&quot;))">
      </testcase>
+          
+     <testcase name="testMillisecWithValidDateTimeString" devName="testMillisecWithValidDateTimeString"
+         labelName="testMillisecWithValidDateTimeString" dataType="Double" eval="formula,template"
+         scale="2" precision="12"
+         code="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))">
+     </testcase>
      
      <testcase name="testTimeValueWithValidInValid" devName="testTimeValueWithValidInValid"
          labelName="testTimeValueWithValidInValid" dataType="TimeOnly" eval="formula,template" dataFile="functiondatevalue-dateandtime"

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecWithValidDateTimeString.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecWithValidDateTimeString.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testMillisecWithValidDateTimeString">
+   <testInstance formula="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))" returntype="Double" precision="12" scale="2">
+    <SqlOutput nullAsNull="true">
+       <Sql>TRUNCATE((NULL -TRUNCATE(NULL/1000,0) * 1000),0)</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>TRUNCATE((NULL -TRUNCATE(NULL/1000,0) * 1000),0)</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>No data</inputvalues>
+         <formula>Error: java.lang.RuntimeException</formula>
+         <sql>null</sql>
+         <formulaNullAsNull>Error: java.lang.RuntimeException</formulaNullAsNull>
+         <sqlNullAsNull>null</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecWithValidDateTimeString.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecWithValidDateTimeString.xml
@@ -2,11 +2,11 @@
 <testCase name="testMillisecWithValidDateTimeString">
    <testInstance formula="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))" returntype="Double" precision="12" scale="2">
     <SqlOutput nullAsNull="true">
-       <Sql>TRUNCATE((NULL -TRUNCATE(NULL/1000,0) * 1000),0)</Sql>
+       <Sql>1000*MICROSECOND(NULL)</Sql>
        <Guard>0=0</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>TRUNCATE((NULL -TRUNCATE(NULL/1000,0) * 1000),0)</Sql>
+       <Sql>1000*MICROSECOND(NULL)</Sql>
        <Guard>0=0</Guard>
     </SqlOutput>
       <result>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecondValueWithValidInValid.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testMillisecondValueWithValidInValid.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testCase name="testMillisecondValueWithValidInValid">
-   <testInstance formula="Second(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
+   <testInstance formula="MilliSecond(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
     <SqlOutput nullAsNull="true">
-       <Sql>SECOND(TIME(TIMESTAMP($!s0s!$.dateString__c)))</Sql>
+       <Sql>1000*MICROSECOND(TIME(TIMESTAMP($!s0s!$.dateString__c)))</Sql>
        <Guard>1=0</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>SECOND(TIME(TIMESTAMP($!s0s!$.dateString__c)))</Sql>
+       <Sql>1000*MICROSECOND(TIME(TIMESTAMP($!s0s!$.dateString__c)))</Sql>
        <Guard>1=0</Guard>
     </SqlOutput>
       <result>
       <inputvalues>[2011-01-29 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-01-9 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-1-29 00:00:00]</inputvalues>
@@ -46,17 +46,17 @@
       </result>
       <result>
       <inputvalues>[2011-1-23 2:22:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-2-7 5:22:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-13-29 00:00:09]</inputvalues>
@@ -95,10 +95,10 @@
       </result>
       <result>
       <inputvalues>[2012-01-01 23:59:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-10-34 00:00:00]</inputvalues>
@@ -109,17 +109,17 @@
       </result>
       <result>
       <inputvalues>[2012-02-07 5:2:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-02-07 5:22:3]</inputvalues>
-         <formula>3</formula>
-         <sql>3</sql>
-         <formulaNullAsNull>3</formulaNullAsNull>
-         <sqlNullAsNull>3</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
    </testInstance>
 </testCase>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testMillisecWithValidDateTimeString">
+   <testInstance formula="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))" returntype="Double" precision="12" scale="2">
+    <SqlOutput nullAsNull="true">
+       <Sql>TRUNC((NULL -TRUNC(NULL/1000) * 1000))</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>TRUNC((NULL -TRUNC(NULL/1000) * 1000))</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>No data</inputvalues>
+         <formula>Error: java.lang.RuntimeException</formula>
+         <sql>null</sql>
+         <formulaNullAsNull>Error: java.lang.RuntimeException</formulaNullAsNull>
+         <sqlNullAsNull>null</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testCase name="testMillisecondValueWithValidInValid">
-   <testInstance formula="Second(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
+   <testInstance formula="MilliSecond(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
     <SqlOutput nullAsNull="true">
-       <Sql>TRUNC((TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000-TRUNC(TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000/60000) * 60000)/1000)</Sql>
+       <Sql>TRUNC((TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000 -TRUNC(TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000/1000) * 1000))</Sql>
        <Guard> NOT REGEXP_LIKE ($!s0s!$.dateString__c, '^\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01]) ([01]?[0-9]|2[0-3]):[0-5]?\d:[0-5]?\d$')/* Adding some comments to keep the same length for this guard as it was before improving to more robust guard*/</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>TRUNC((TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000-TRUNC(TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000/60000) * 60000)/1000)</Sql>
+       <Sql>TRUNC((TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000 -TRUNC(TO_NUMBER(TO_CHAR(TO_DATE($!s0s!$.dateString__c, 'YYYY-MM-DD HH24:MI:SS'), 'SSSSS')) * 1000/1000) * 1000))</Sql>
        <Guard> NOT REGEXP_LIKE ($!s0s!$.dateString__c, '^\d{4}-(0?[1-9]|1[012])-(0?[1-9]|[12][0-9]|3[01]) ([01]?[0-9]|2[0-3]):[0-5]?\d:[0-5]?\d$')/* Adding some comments to keep the same length for this guard as it was before improving to more robust guard*/</Guard>
     </SqlOutput>
       <result>
       <inputvalues>[2011-01-29 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-01-9 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-1-29 00:00:00]</inputvalues>
@@ -46,17 +46,17 @@
       </result>
       <result>
       <inputvalues>[2011-1-23 2:22:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-2-7 5:22:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-13-29 00:00:09]</inputvalues>
@@ -95,10 +95,10 @@
       </result>
       <result>
       <inputvalues>[2012-01-01 23:59:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-10-34 00:00:00]</inputvalues>
@@ -109,17 +109,17 @@
       </result>
       <result>
       <inputvalues>[2012-02-07 5:2:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-02-07 5:22:3]</inputvalues>
-         <formula>3</formula>
-         <sql>3</sql>
-         <formulaNullAsNull>3</formulaNullAsNull>
-         <sqlNullAsNull>3</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
    </testInstance>
 </testCase>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testMillisecWithValidDateTimeString.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testMillisecWithValidDateTimeString">
+   <testInstance formula="MilliSecond(TIMEVALUE(&quot;2015-03-17 17:00:00&quot;))" returntype="Double" precision="12" scale="2">
+    <SqlOutput nullAsNull="true">
+       <Sql>DATEPART(MILLISECOND,NULL)</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>DATEPART(MILLISECOND,NULL)</Sql>
+       <Guard>0=0</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>No data</inputvalues>
+         <formula>Error: java.lang.RuntimeException</formula>
+         <sql>null</sql>
+         <formulaNullAsNull>Error: java.lang.RuntimeException</formulaNullAsNull>
+         <sqlNullAsNull>null</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testMillisecondValueWithValidInValid.xml
@@ -1,27 +1,27 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testCase name="testMillisecondValueWithValidInValid">
-   <testInstance formula="Second(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
+   <testInstance formula="MilliSecond(TimeValue(DATETIMEVALUE(dateString__c)))" returntype="Double" precision="12" scale="2">
     <SqlOutput nullAsNull="true">
-       <Sql>DATEPART(second,CAST(CONVERT(DATETIME, $!s0s!$.dateString__c) as TIME))</Sql>
+       <Sql>DATEPART(MILLISECOND,CAST(CONVERT(DATETIME, $!s0s!$.dateString__c) as TIME))</Sql>
        <Guard>1=0</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>DATEPART(second,CAST(CONVERT(DATETIME, $!s0s!$.dateString__c) as TIME))</Sql>
+       <Sql>DATEPART(MILLISECOND,CAST(CONVERT(DATETIME, $!s0s!$.dateString__c) as TIME))</Sql>
        <Guard>1=0</Guard>
     </SqlOutput>
       <result>
       <inputvalues>[2011-01-29 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-01-9 00:00:09]</inputvalues>
-         <formula>9</formula>
-         <sql>9</sql>
-         <formulaNullAsNull>9</formulaNullAsNull>
-         <sqlNullAsNull>9</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-1-29 00:00:00]</inputvalues>
@@ -46,17 +46,17 @@
       </result>
       <result>
       <inputvalues>[2011-1-23 2:22:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-2-7 5:22:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2011-13-29 00:00:09]</inputvalues>
@@ -95,10 +95,10 @@
       </result>
       <result>
       <inputvalues>[2012-01-01 23:59:59]</inputvalues>
-         <formula>59</formula>
-         <sql>59</sql>
-         <formulaNullAsNull>59</formulaNullAsNull>
-         <sqlNullAsNull>59</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-10-34 00:00:00]</inputvalues>
@@ -109,17 +109,17 @@
       </result>
       <result>
       <inputvalues>[2012-02-07 5:2:33]</inputvalues>
-         <formula>33</formula>
-         <sql>33</sql>
-         <formulaNullAsNull>33</formulaNullAsNull>
-         <sqlNullAsNull>33</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
       <result>
       <inputvalues>[2012-02-07 5:22:3]</inputvalues>
-         <formula>3</formula>
-         <sql>3</sql>
-         <formulaNullAsNull>3</formulaNullAsNull>
-         <sqlNullAsNull>3</sqlNullAsNull>
+         <formula>0</formula>
+         <sql>0</sql>
+         <formulaNullAsNull>0</formulaNullAsNull>
+         <sqlNullAsNull>0</sqlNullAsNull>
       </result>
    </testInstance>
 </testCase>


### PR DESCRIPTION
With invalid timevalues, the millisecond code returns an error, instead of null values.  This causes a regression.
Also update the labels with all the new functions
@dgyawali 