### PR TITLE
SingleValueContext

### DIFF
--- a/api/src/main/java/com/force/formula/FormulaReturnType.java
+++ b/api/src/main/java/com/force/formula/FormulaReturnType.java
@@ -11,7 +11,9 @@ public interface FormulaReturnType {
     /**
      * @return the name of the field,  if it's a custom formula field
      */
-    String getName();
+    default String getName() {
+        return null;
+    }
 
     /**
      * @return the DataType of this formula
@@ -21,7 +23,9 @@ public interface FormulaReturnType {
     /**
      * @return scale of the number, if the return type is a number
      */
-    int getScale();
+    default int getScale() {
+        return 32;
+    }
     
     /**
      * @return the FieldOrColumnInfo backing this formula.  This may return null as some formulas are not applicable to fields or columns.

--- a/api/src/main/java/com/force/formula/util/BaseCompositeFormulaContext.java
+++ b/api/src/main/java/com/force/formula/util/BaseCompositeFormulaContext.java
@@ -3,10 +3,30 @@ package com.force.formula.util;
 import java.math.BigDecimal;
 import java.sql.Connection;
 import java.sql.SQLException;
-import java.util.*;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.Map;
 
-import com.force.formula.*;
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.DisplayField;
+import com.force.formula.FormulaCommandType;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaCurrencyData;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaEvaluationException;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaGeolocation;
+import com.force.formula.FormulaReturnType;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.FormulaSchema;
 import com.force.formula.FormulaSchema.ApiElement;
+import com.force.formula.FormulaTime;
+import com.force.formula.FormulaTypeSpec;
+import com.force.formula.GlobalFormulaProperties;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.UnsupportedTypeException;
 import com.google.common.base.Ascii;
 
 /**
@@ -23,29 +43,6 @@ public class BaseCompositeFormulaContext implements FormulaRuntimeContext {
     public interface FormulaRuntimeContextProvider {
         FormulaRuntimeContext get(FormulaContext outerContext) throws FormulaException, SQLException;
     }
-    
-    // Use this to prevent any funny business with formula properties
-    public static class ConstantGlobalFormulaProperties extends GlobalFormulaProperties {
-        public ConstantGlobalFormulaProperties(FormulaTypeSpec topLevelType) {
-            super(topLevelType);
-        }
-
-        @Override
-        public void pushFormulaType(FormulaTypeSpec type) {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public FormulaTypeSpec popFormulaType() {
-            throw new UnsupportedOperationException();
-        }
-
-        @Override
-        public void setShouldIgnoreFls(boolean ignore) {
-            throw new UnsupportedOperationException();
-        }
-    }
-    
 
     public BaseCompositeFormulaContext(FormulaRuntimeContext defaultContext, FormulaTypeSpec topLevelFormulaType) {
         this.defaultContext = defaultContext;
@@ -54,6 +51,15 @@ public class BaseCompositeFormulaContext implements FormulaRuntimeContext {
         this.additionalContexts = new HashMap<String, FormulaRuntimeContext>();
         this.allowSelfReference = true;
     }
+
+    public BaseCompositeFormulaContext(FormulaRuntimeContext defaultContext, GlobalFormulaProperties globalProperties) {
+        this.defaultContext = defaultContext;
+        this.globalFormulaProperties = globalProperties;
+        this.additionalContextProviders = new HashMap<String, FormulaRuntimeContextProvider>();
+        this.additionalContexts = new HashMap<String, FormulaRuntimeContext>();
+        this.allowSelfReference = true;
+    }
+
 
     /**
      * Provide a way for a child formula context to filter out formulas simply without breaking inheritance

--- a/api/src/main/java/com/force/formula/util/BaseRootFormulaContext.java
+++ b/api/src/main/java/com/force/formula/util/BaseRootFormulaContext.java
@@ -1,0 +1,62 @@
+/**
+ * 
+ */
+package com.force.formula.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.force.formula.FormulaCommandType;
+import com.force.formula.FormulaReturnType;
+import com.force.formula.FormulaTypeSpec;
+
+/**
+ * Class for implementing a "base" Formula Context with an "intended" return type.
+ * 
+ * You should be able to extend this and produce a formula context suitable for the "root"
+ *
+ * @author stamm
+ * @since 0.2.6
+ */
+public abstract class BaseRootFormulaContext extends BaseCompositeFormulaContext {
+    private final FormulaReturnType returnType;
+
+    /**
+     * @param outerContext
+     */
+    public BaseRootFormulaContext(FormulaTypeSpec topLevelFormulaType, FormulaReturnType returnType) {
+        super(null, topLevelFormulaType);
+        this.returnType = returnType;
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public FormulaReturnType getFormulaReturnType() {
+        return this.returnType;
+    }
+
+    @Override
+    public boolean isFunctionSupported(FormulaCommandType function) {
+        return true;
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <P> P getProperty(String name) {
+        return (P)properties.get(name);
+    }
+
+    @Override
+    public void setProperty(String name, Object value) {
+        properties.put(name, value);
+    }
+    
+
+    private final Map<String, Object> properties = new HashMap<>(4);
+
+
+}

--- a/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
+++ b/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
@@ -13,7 +13,6 @@ import com.force.formula.FormulaDataType;
 import com.force.formula.FormulaDateTime;
 import com.force.formula.FormulaGeolocation;
 import com.force.formula.FormulaReturnType;
-import com.force.formula.FormulaRuntimeContext;
 import com.force.formula.FormulaSchema;
 import com.force.formula.FormulaTime;
 import com.force.formula.FormulaTypeSpec;
@@ -28,7 +27,7 @@ import com.force.formula.UnsupportedTypeException;
  * @author stamm
  * @since 0.2.6
  */
-public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
+public class SingleValueFormulaContext<T> extends BaseRootFormulaContext {
     public static final String VALUE_NAME = "Value";
     
     private final FormulaDataType dataType;
@@ -37,8 +36,8 @@ public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
     /**
      * @param outerContext
      */
-    public SingleValueFormulaContext(FormulaRuntimeContext outerContext, FormulaTypeSpec topLevelFormulaType, FormulaDataType dataType, T value) {
-        super(outerContext, topLevelFormulaType);
+    public SingleValueFormulaContext(FormulaTypeSpec topLevelFormulaType, FormulaReturnType returnType, FormulaDataType dataType, T value) {
+        super(topLevelFormulaType, returnType);
         this.dataType = dataType;
         this.value = value;
     }
@@ -149,16 +148,6 @@ public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
     }
 
     @Override
-    public String getName() {
-        return null;
-    }
-
-    @Override
-    public FormulaReturnType getFormulaReturnType() {
-        return null;
-    }
-
-    @Override
     public ContextualFormulaFieldInfo lookup(String name, boolean isDynamicRefBase) throws InvalidFieldReferenceException, UnsupportedTypeException {
         if (getValueName().equalsIgnoreCase(name)) {
             return new SingleValueFormulaFieldInfo(getValueName(), this.getValueType());
@@ -184,8 +173,8 @@ public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
     public String fromDurableName(String reference) throws InvalidFieldReferenceException, UnsupportedTypeException {
         return reference;
     }
-
-    static class SingleValueFormulaFieldInfo extends FormulaFieldInfoImpl {
+    
+    class SingleValueFormulaFieldInfo extends FormulaFieldInfoImpl {
 
         public SingleValueFormulaFieldInfo(String name, FormulaDataType columnType) {
             super(name, name, name);
@@ -204,5 +193,4 @@ public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
 
         private final FormulaDataType columnType;
     }
-
 }

--- a/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
+++ b/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
@@ -1,0 +1,208 @@
+/**
+ * 
+ */
+package com.force.formula.util;
+
+import java.math.BigDecimal;
+import java.util.Date;
+
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.DisplayField;
+import com.force.formula.FormulaCurrencyData;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaGeolocation;
+import com.force.formula.FormulaReturnType;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.FormulaSchema;
+import com.force.formula.FormulaTime;
+import com.force.formula.FormulaTypeSpec;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.UnsupportedTypeException;
+
+/**
+ * Class for implementing a Formula Context with a single value, normally called "Value."
+ * This is intended to be used for writing validation formulas of a single value like 
+ * <tt>Value > 0</tt> 
+ *
+ * @author stamm
+ * @since 0.2.6
+ */
+public class SingleValueFormulaContext<T> extends BaseCompositeFormulaContext {
+    public static final String VALUE_NAME = "Value";
+    
+    private final FormulaDataType dataType;
+    private final T value;
+    
+    /**
+     * @param outerContext
+     */
+    public SingleValueFormulaContext(FormulaRuntimeContext outerContext, FormulaTypeSpec topLevelFormulaType, FormulaDataType dataType, T value) {
+        super(outerContext, topLevelFormulaType);
+        this.dataType = dataType;
+        this.value = value;
+    }
+    
+    /**
+     * @return the name of the field reference for this value
+     */
+    public String getValueName() {
+        return VALUE_NAME;
+    }
+    
+    public FormulaDataType getValueType() {
+        return this.dataType;
+    }
+
+    public T getValue() {
+         return this.value;
+    }
+
+    @Override
+    public FormulaDateTime getDateTime(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (FormulaDateTime) getValue();
+        } else {
+            return super.getDateTime(fieldName);
+        }
+    }
+
+    @Override
+    public BigDecimal getNumber(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (BigDecimal) getValue();
+        } else {
+            return super.getNumber(fieldName);
+        }
+    }
+
+    @Override
+    public String getString(String fieldName, boolean useNative)
+            throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (String) getValue();
+        } else {
+            return super.getString(fieldName, useNative);
+        }
+    }
+
+    @Override
+    public Date getDate(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (Date) getValue();
+        } else {
+            return super.getDate(fieldName);
+        }
+    }
+
+    @Override
+    public FormulaTime getTime(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (FormulaTime) getValue();
+        } else {
+            return super.getTime(fieldName);
+        }
+    }
+
+    @Override
+    public FormulaCurrencyData getCurrency(String fieldName)
+            throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (FormulaCurrencyData) getValue();
+        } else {
+            return super.getCurrency(fieldName);
+        }
+    }
+
+    @Override
+    public Object getObject(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return getValue();
+        } else {
+            return super.getObject(fieldName);
+        }
+    }
+
+    @Override
+    public String getMaskedString(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (String) getValue();
+        } else {
+            return super.getMaskedString(fieldName);
+        }
+    }
+
+    @Override
+    public FormulaGeolocation getLocation(String fieldName) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (fieldName.equalsIgnoreCase(getValueName())) {
+            return (FormulaGeolocation) getValue();
+        } else {
+            return super.getLocation(fieldName);
+        }
+    }
+
+    @Override
+    public DisplayField[] getDisplayFields(FormulaSchema.Entity entityInfo) {
+        return new DisplayField[] {
+             new DisplayField(getValueName(), getValueName(), new SingleValueFormulaFieldInfo(getValueName(), this.getValueType()))
+        };
+    }
+
+    @Override
+    public String getName() {
+        return null;
+    }
+
+    @Override
+    public FormulaReturnType getFormulaReturnType() {
+        return null;
+    }
+
+    @Override
+    public ContextualFormulaFieldInfo lookup(String name, boolean isDynamicRefBase) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        if (getValueName().equalsIgnoreCase(name)) {
+            return new SingleValueFormulaFieldInfo(getValueName(), this.getValueType());
+        } else {
+            throw new InvalidFieldReferenceException(name, "Unknown field");
+        }
+    }
+
+    @Override
+    public String toDurableName(String name) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        return name;
+    }
+
+    @Override
+    public String toJavascriptName(String name) throws InvalidFieldReferenceException {
+        if (getValueName().equals(name)) {
+            return getValueName();
+        }
+        return name;
+    }
+    
+    @Override
+    public String fromDurableName(String reference) throws InvalidFieldReferenceException, UnsupportedTypeException {
+        return reference;
+    }
+
+    static class SingleValueFormulaFieldInfo extends FormulaFieldInfoImpl {
+
+        public SingleValueFormulaFieldInfo(String name, FormulaDataType columnType) {
+            super(name, name, name);
+            this.columnType = columnType;
+        }
+
+        @Override
+        public FormulaDataType getDataType() {
+            return columnType;
+        }
+
+        @Override
+        public String getDbColumn(String standardTablAlias, String customTableAlias) {
+            throw new UnsupportedOperationException();
+        }
+
+        private final FormulaDataType columnType;
+    }
+
+}

--- a/api/src/test/java/com/force/formula/util/BaseCompositeFormulaContextTest.java
+++ b/api/src/test/java/com/force/formula/util/BaseCompositeFormulaContextTest.java
@@ -153,14 +153,6 @@ public class BaseCompositeFormulaContextTest {
 	static FormulaReturnType getReturnType() {
 		return new FormulaReturnType() {
 			@Override
-			public int getScale() {
-				return 0;
-			}
-			@Override
-			public String getName() {
-				return "name";
-			}
-			@Override
 			public FormulaDataType getDataType() {
 				return new FormulaDataType() {
 					@Override

--- a/api/src/test/java/com/force/formula/util/SingleValueFormulaContextTest.java
+++ b/api/src/test/java/com/force/formula/util/SingleValueFormulaContextTest.java
@@ -1,0 +1,163 @@
+/**
+ * 
+ */
+package com.force.formula.util;
+
+import java.math.BigDecimal;
+import java.time.LocalTime;
+import java.util.Date;
+import java.util.concurrent.Callable;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaEvaluationException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.FormulaTime;
+import com.force.formula.FormulaTypeSpec;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.UnsupportedTypeException;
+
+
+/**
+ * Test of SingleValueFormulaContext.
+ *
+ * @author stamm
+ * @since 0.2
+ */
+public class SingleValueFormulaContextTest {
+    
+    @Before
+    public void setup() {
+        BaseCompositeFormulaContextTest.setLocalizer();
+    }
+    
+    @Test(expected = FormulaEvaluationException.class)
+    public void testBoolean() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, null);
+        context.getBoolean("Value");
+    }
+
+    @Test
+    public void testGetString() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, "Hi");
+        checkValidValue(context, (key)->context.getString(key, false), "Hi");
+    }
+    
+    @Test
+    public void testLookup() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, "Hi");
+        ContextualFormulaFieldInfo ffi = context.lookup("value");
+        Assert.assertEquals(null, ffi.getDataType());
+        Assert.assertEquals("Value", ffi.getName());
+    }
+    
+
+    @Test
+    public void testGetMethods() throws Exception {
+        SingleValueFormulaContext c0 = new TestSingleValueFormulaContext(null, "Hi");
+        checkValidValue(c0, (key)->c0.getString(key, false), "Hi");
+        checkValidValue(c0, (key)->c0.getMaskedString(key), "Hi");
+
+        Date d = new Date();
+        final SingleValueFormulaContext c1 = new TestSingleValueFormulaContext(null, d);
+        checkValidValue(c1, (key)->c1.getDate(key), d);
+   
+        FormulaDateTime dt = new FormulaDateTime(new Date());
+        final SingleValueFormulaContext c2 = new TestSingleValueFormulaContext(null, dt);
+        checkValidValue(c2, (key)->c2.getDateTime(key), dt);
+
+        BigDecimal n = BigDecimal.ONE;
+        final SingleValueFormulaContext c3 = new TestSingleValueFormulaContext(null, n);
+        checkValidValue(c3, (key)->c3.getNumber(key), n);
+   
+        FormulaTime t = new FormulaTime.TimeWrapper(LocalTime.now());
+        final SingleValueFormulaContext c4 = new TestSingleValueFormulaContext(null, t);
+        checkValidValue(c4, (key)->c4.getTime(key), t);
+    }
+    
+    // Test lowercase/uppercase and getObject for each type
+    <T> void checkValidValue(FormulaRuntimeContext context, ContextLookup<T> v, T value) throws Exception {
+        Assert.assertEquals(value, v.apply("Value"));
+        Assert.assertEquals(value, v.apply("value"));
+        Assert.assertEquals(value, context.getObject("Value"));
+        Assert.assertEquals(value, context.getObject("value"));
+    }
+    
+    
+    @FunctionalInterface
+    interface ContextLookup<V> {
+        V apply(String t) throws InvalidFieldReferenceException, UnsupportedTypeException;
+    }
+    
+    @Test
+    public void testInvalidValue() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, "Hi");
+        checkInvalidValue(() -> context.getString("invalid", false));
+        checkInvalidValue(() -> context.getDate("invalid"));
+        checkInvalidValue(() -> context.getDateTime("invalid"));
+        checkInvalidValue(() -> context.getBoolean("invalid"));
+        checkInvalidValue(() -> context.getObject("invalid"));
+        checkInvalidValue(() -> context.getCurrency("invalid"));
+        checkInvalidValue(() -> context.getLocation("invalid"));
+        checkInvalidValue(() -> context.getMaskedString("invalid"));
+        checkInvalidValue(() -> context.getNumber("invalid"));
+        checkInvalidValue(() -> context.getTime("invalid"));
+    }
+  
+    void checkInvalidValue(Callable<?> v) throws Exception {
+        try {
+            v.call();
+            Assert.fail();
+        } catch (FormulaEvaluationException x) {
+            Assert.assertTrue(x.getCause() instanceof InvalidFieldReferenceException);
+        }
+    }
+
+    @Test(expected = ClassCastException.class)
+    public void testGetWrongType() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, new Date());
+        context.getString("Value", false);
+    }
+
+    
+    @Test
+    public void testAlternateName() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, BigDecimal.ONE) {
+            @Override
+            public String getValueName() {
+                return "Num";
+            }
+            
+        };
+        ContextualFormulaFieldInfo ffi = context.lookup("num");
+        Assert.assertEquals(null, ffi.getDataType());
+        Assert.assertEquals("Num", ffi.getName());
+        Assert.assertEquals(BigDecimal.ONE, context.getNumber("num"));
+    }
+    
+    
+    static class TestSingleValueFormulaContext extends SingleValueFormulaContext<Object> {
+        public TestSingleValueFormulaContext(FormulaDataType type, Object value) {
+            super(null, new FormulaTypeSpec() {
+                @Override
+                public int getMaxLength() {
+                    return 0;
+                }
+                @Override
+                public String getDisplay() {
+                    return "display";
+                }
+                @Override
+                public FormulaProperties getDefaultProperties() {
+                    return new FormulaProperties();
+                }
+            }, type, value);
+        }
+    }
+}

--- a/api/src/test/java/com/force/formula/util/SingleValueFormulaContextTest.java
+++ b/api/src/test/java/com/force/formula/util/SingleValueFormulaContextTest.java
@@ -17,6 +17,7 @@ import com.force.formula.FormulaDataType;
 import com.force.formula.FormulaDateTime;
 import com.force.formula.FormulaEvaluationException;
 import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaReturnType;
 import com.force.formula.FormulaRuntimeContext;
 import com.force.formula.FormulaTime;
 import com.force.formula.FormulaTypeSpec;
@@ -142,9 +143,18 @@ public class SingleValueFormulaContextTest {
     }
     
     
+    @Test
+    public void testProperties() throws Exception {
+        SingleValueFormulaContext context = new TestSingleValueFormulaContext(null, BigDecimal.ONE);
+        Assert.assertEquals(null, context.<Object>getProperty("foo"));
+        context.setProperty("foo", "bar");
+        Assert.assertEquals("bar", context.getProperty("foo"));
+    }
+    
+    
     static class TestSingleValueFormulaContext extends SingleValueFormulaContext<Object> {
         public TestSingleValueFormulaContext(FormulaDataType type, Object value) {
-            super(null, new FormulaTypeSpec() {
+            super(new FormulaTypeSpec() {
                 @Override
                 public int getMaxLength() {
                     return 0;
@@ -156,6 +166,11 @@ public class SingleValueFormulaContextTest {
                 @Override
                 public FormulaProperties getDefaultProperties() {
                     return new FormulaProperties();
+                }
+            }, new FormulaReturnType() {
+                @Override
+                public FormulaDataType getDataType() {
+                    return null;
                 }
             }, type, value);
         }

--- a/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
+++ b/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
@@ -8,6 +8,7 @@ package com.force.formula.commands;
 import java.util.TimeZone;
 
 import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaException;
 import com.force.formula.MockFormulaType;
 
 /**
@@ -39,7 +40,7 @@ public class BuiltinFunctionsJsTest extends BuiltinFunctionsTest {
     }
 
     @Override
-    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws Exception {
+    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws FormulaException {
     	return evaluateJavascript(formulaSource, columnType);
     }
 

--- a/impl/src/test/java/com/force/formula/commands/FunctionIfsTest.java
+++ b/impl/src/test/java/com/force/formula/commands/FunctionIfsTest.java
@@ -7,8 +7,14 @@ import java.util.stream.Stream;
 
 import org.junit.Test;
 
-import com.force.formula.*;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaException;
+import com.force.formula.MockFormulaDataType;
+import com.force.formula.MockFormulaType;
+import com.force.formula.impl.BaseCustomizableParserTest;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.impl.sql.FormulaDefaultSqlStyle;
 import com.force.formula.sql.SQLPair;
 
@@ -68,7 +74,7 @@ public class FunctionIfsTest extends BaseCustomizableParserTest {
     	return isJs() ? MockFormulaType.JAVASCRIPT : MockFormulaType.DEFAULT;
     }
     @Override
-    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws Exception {
+    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws FormulaException {
     	if (!isJs()) {
     		return super.evaluate(formulaSource, columnType);
     	} else {

--- a/impl/src/test/java/com/force/formula/commands/OptionalFunctionsJsTest.java
+++ b/impl/src/test/java/com/force/formula/commands/OptionalFunctionsJsTest.java
@@ -8,6 +8,7 @@ package com.force.formula.commands;
 import java.util.TimeZone;
 
 import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaException;
 import com.force.formula.MockFormulaType;
 
 /**
@@ -39,7 +40,7 @@ public class OptionalFunctionsJsTest extends OptionalFunctionsTest {
     }
 
     @Override
-    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws Exception {
+    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws FormulaException {
     	return evaluateJavascript(formulaSource, columnType);
     }
 

--- a/impl/src/test/java/com/force/formula/impl/FieldReferenceJsTest.java
+++ b/impl/src/test/java/com/force/formula/impl/FieldReferenceJsTest.java
@@ -3,7 +3,13 @@ package com.force.formula.impl;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.force.formula.*;
+import com.force.formula.Formula;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaException;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.MockFormulaType;
+import com.force.formula.RuntimeFormulaInfo;
+import com.force.formula.UnsupportedTypeException;
 import com.force.formula.commands.FormulaJsTestUtils;
 import com.google.common.collect.ImmutableMap;
 
@@ -29,7 +35,7 @@ public class FieldReferenceJsTest extends BaseFieldReferenceTest {
     }
 
     @Override
-    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws Exception {
+    protected Object evaluate(String formulaSource, FormulaDataType columnType) throws FormulaException {
         BeanFormulaContext context = setupMockContext(columnType);
         RuntimeFormulaInfo formulaInfo = FormulaInfoFactory.create(getFormulaType(), context, formulaSource);
         Formula formula = formulaInfo.getFormula();

--- a/impl/src/test/java/com/force/formula/impl/ValidationFormulaTest.java
+++ b/impl/src/test/java/com/force/formula/impl/ValidationFormulaTest.java
@@ -1,0 +1,76 @@
+/**
+ * 
+ */
+package com.force.formula.impl;
+
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaFactory;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.FormulaTestBase;
+import com.force.formula.MockFormulaDataType;
+import com.force.formula.MockFormulaType;
+import com.force.formula.impl.BaseCustomizableParserTest.FieldTestFormulaValidationHooks;
+import com.force.formula.util.SingleValueFormulaContext;
+
+/**
+ * Test of SingleValueFormulaContext in the context of a 
+ *
+ * @author stamm
+ * @since 0.2.5
+ */
+public class ValidationFormulaTest extends FormulaTestBase {
+    Object singleValue;
+    FormulaDataType singleType;
+
+    public ValidationFormulaTest(String name) {
+        super(name);
+    }
+    
+    FormulaFactory oldFactory = FormulaEngine.getFactory();
+    FieldTestFormulaValidationHooks hooks;
+
+    @Override
+    protected void setUp() throws Exception {
+        oldFactory = FormulaEngine.getFactory();
+        FormulaEngine.setFactory(BaseCustomizableParserTest.TEST_FACTORY);
+        super.setUp();
+    }
+
+    @Override
+    protected void tearDown() throws Exception {
+        FormulaEngine.setFactory(oldFactory);
+        super.tearDown();
+    }
+    
+    
+    protected FormulaDataType getSingleType() {
+        return singleType;
+    }
+    
+    protected Object getSingleValue() {
+        return singleValue;
+    }
+    
+    public void testStringValue() throws FormulaException {
+        singleValue = "Hello";
+        singleType = MockFormulaDataType.TEXT;
+        assertTrue(evaluateBoolean("Value != NULL"));
+        assertFalse(evaluateBoolean("Value = NULL"));
+        assertTrue(evaluateBoolean("LEN(Value)>4"));
+   }
+        
+        
+    @Override
+    protected MockFormulaType getFormulaType() {
+        return MockFormulaType.TEMPLATE;
+    }
+
+    @Override
+    protected FormulaRuntimeContext setupMockContext(FormulaDataType dataType) {
+        return new SingleValueFormulaContext<Object>(getFormulaType(),
+                ()->dataType, getSingleType(), getSingleValue());
+    }
+
+}

--- a/test-utils/src/main/java/com/force/formula/MockFormulaContext.java
+++ b/test-utils/src/main/java/com/force/formula/MockFormulaContext.java
@@ -55,18 +55,6 @@ public class MockFormulaContext extends NullFormulaContext {
                 // for now we only return formulas that evaluate to numbers
                 return returnType;
             }
-            @Override
-            public FormulaSchema.FieldOrColumn getFieldOrColumnInfo() {
-                return null;
-            }
-            @Override
-            public String getName() {
-                return null;
-            }
-            @Override
-            public int getScale() {
-                return 32;
-            }
         };
     }
 


### PR DESCRIPTION
Create SingleValueFormulaContex to more easily validate single values (i.e Value>0)
Create BaseRootFormulaContext to make it simpler to create "root" contexts with BaseRootFormulaContext
Make FormulaReturnType support FunctionInterface with default implementations
Switch exceptions in tests from throws Exception to throws FormulaException
@dgyawali @bmazyan 