### PR TITLE
FormulaFieldInfoAdapter equals/hashcode

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FormulaCommandInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/commands/FormulaCommandInfoImpl.java
@@ -3,11 +3,19 @@ package com.force.formula.commands;
 import java.lang.reflect.Type;
 import java.util.Arrays;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommandType;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
-import com.force.formula.sql.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaException;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.FormulaValidationHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.sql.ITableAliasRegistry;
+import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaTextUtil;
 
 /**
@@ -180,14 +188,14 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      * 
      * @return whether to use the "Decimal" or "Math" packages for math functions
      */
-    static String jsMathPkg(FormulaContext context) {
+    protected static String jsMathPkg(FormulaContext context) {
 		return context.useHighPrecisionJs() ? "$F.Decimal" : "Math";
     }
 
     /**
      * Convert the value *to* a high precision decimal from a javascript number
      */
-    static String jsToDec(FormulaContext context, String val) {
+    protected static String jsToDec(FormulaContext context, String val) {
         return context.useHighPrecisionJs() ? "(new $F.Decimal(" + val + "))" : val;
     }
 
@@ -198,7 +206,7 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      * @param val
      * @return
      */
-    static String jsToNum(FormulaContext context, String val) {
+    protected static String jsToNum(FormulaContext context, String val) {
         return context.useHighPrecisionJs() ? val + ".toNumber()" : val;
     }
 

--- a/impl/src/main/java/com/force/formula/impl/FormulaFieldInfoAdapter.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaFieldInfoAdapter.java
@@ -1,6 +1,17 @@
 package com.force.formula.impl;
 
-import com.force.formula.*;
+import java.util.Objects;
+
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.Formula;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaFieldInfo;
+import com.force.formula.FormulaPicklistInfo;
+import com.force.formula.FormulaProvider;
+import com.force.formula.FormulaSchema;
+import com.force.formula.FormulaTypeSpec;
 import com.force.formula.sql.FormulaSQLProvider;
 import com.force.formula.util.FormulaFieldInfoImpl;
 
@@ -111,6 +122,20 @@ public abstract class FormulaFieldInfoAdapter extends FormulaFieldInfoImpl imple
     @Override
     public FormulaContext getFormulaContext() {
         return info.getFormulaContext();
+    }
+    
+    @Override
+    public int hashCode() {
+        return super.hashCode() * Objects.hash(this.namespace, this.fieldOrColumnInfo, this.info);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (!super.equals(obj)) return false;
+        FormulaFieldInfoAdapter other = (FormulaFieldInfoAdapter) obj;
+        return Objects.equals(this.namespace, other.namespace)
+                && Objects.equals(this.fieldOrColumnInfo, other.fieldOrColumnInfo)
+                && Objects.equals(this.info, other.info);
     }
 
     private final String namespace;


### PR DESCRIPTION
Equals/Hashcode weren't implemented correctly on the FFIA subclass causing issues with consumers from the #52 change

Also make some package protected methods be protected methods to FormulaCommandInfoImpl so subclasses in other packages can access them easily