### PR TITLE
Catch StackOverflowError during FormulaAST visiting

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -6,16 +6,50 @@ package com.force.formula.impl;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Date;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 
-import com.force.formula.*;
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.Formula;
+import com.force.formula.FormulaCommand;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaFieldInfo;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaProvider;
+import com.force.formula.FormulaReturnType;
+import com.force.formula.FormulaRuntimeContext;
 import com.force.formula.FormulaRuntimeContext.InaccessibleFieldStrategy;
-import com.force.formula.commands.*;
+import com.force.formula.FormulaSchema;
+import com.force.formula.FormulaTime;
+import com.force.formula.FormulaTooLongException;
+import com.force.formula.FormulaTypeWithDomain;
+import com.force.formula.GenericFormulaException;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.JSTooBigException;
+import com.force.formula.RuntimeFormulaInfo;
+import com.force.formula.commands.ConstantNull;
+import com.force.formula.commands.FormulaCommandEnricher;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoRegistry;
+import com.force.formula.commands.FormulaCommandOptimizer;
+import com.force.formula.commands.RuntimeType;
 import com.force.formula.impl.FormulaCommandVisitorImpl.FormatCurrencyVisitor;
 import com.force.formula.parser.gen.FormulaTokenTypes;
-import com.force.formula.sql.*;
+import com.force.formula.sql.FormulaWithSql;
+import com.force.formula.sql.InvalidFormula;
+import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.formula.util.FormulaTextUtil;
 import com.google.common.base.Joiner;
@@ -702,7 +736,11 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
         catch (FormulaException x) {
             handleVisitExceptions(x, node, visitor, properties);
         }
-
+        catch (StackOverflowError x) {
+            // Throw a formula exception to allow debugging of recursion errors.
+            throw new GenericFormulaException(x);
+        }
+        
         try {
             if (firstSibling != null) {
                 visit(firstSibling, visitor, properties);
@@ -710,6 +748,10 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
         }
         catch (FormulaException x) {
             handleVisitExceptions(x, node, visitor, properties);
+        }
+        catch (StackOverflowError x) {
+            // Throw a formula exception to allow debugging of recursion errors.
+            throw new GenericFormulaException(x);
         }
     }
 


### PR DESCRIPTION
StackOverflowErrors aren't handled gracefully, but seems to be occurring
in production.  Since there is some tree reparenting, this will give a better
stack trace.