### PR TITLE
Change recursive impl to iterative for BaseFormulaInfoImpl.visit()

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -688,31 +688,8 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
 
     public static void visit(FormulaAST node, FormulaASTVisitor visitor, FormulaProperties properties)
             throws FormulaException {
-        /* FormulaAST firstSibling = (FormulaAST)node.getNextSibling();
-
-        try {
-            FormulaAST firstChild = (FormulaAST)node.getFirstChild();
-            if (firstChild != null) {
-                visit(firstChild, visitor, properties);
-            }
-
-            visitor.visit(node);
-        }
-        catch (FormulaException x) {
-            handleVisitExceptions(x, node, visitor, properties);
-        }
-
-        try {
-            if (firstSibling != null) {
-                visit(firstSibling, visitor, properties);
-            }
-        }
-        catch (FormulaException x) {
-            handleVisitExceptions(x, node, visitor, properties);
-        }*/
-
         /**
-         * As the above recursive inorder traversal was resulting in StackOverFlow error when the tree is skewed or
+         * As the recursive inorder traversal was resulting in StackOverFlow error when the tree is skewed or
          * deeply nested, using iterative implementation to do the same work
          */
 
@@ -721,7 +698,7 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
 
     // Iterative function to perform inorder traversal on the tree
     private static void visitInorderIterative(FormulaAST node, FormulaASTVisitor visitor, FormulaProperties properties) throws FormulaException{
-        Stack<FormulaAST> stack = new Stack<>();
+        Deque<FormulaAST> stack = new ArrayDeque<>();
         FormulaAST curr = node;
         while (curr != null || !stack.isEmpty()) {
             while (curr != null) {

--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -686,10 +686,9 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
         return commandInfo.getJavascript(ast, context, args);
     }
 
-
     public static void visit(FormulaAST node, FormulaASTVisitor visitor, FormulaProperties properties)
-        throws FormulaException {
-        FormulaAST firstSibling = (FormulaAST)node.getNextSibling();
+            throws FormulaException {
+        /* FormulaAST firstSibling = (FormulaAST)node.getNextSibling();
 
         try {
             FormulaAST firstChild = (FormulaAST)node.getFirstChild();
@@ -710,6 +709,32 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
         }
         catch (FormulaException x) {
             handleVisitExceptions(x, node, visitor, properties);
+        }*/
+
+        /**
+         * As the above recursive inorder traversal was resulting in StackOverFlow error when the tree is skewed or
+         * deeply nested, using iterative implementation to do the same work
+         */
+
+        visitInorderIterative(node, visitor, properties);
+    }
+
+    // Iterative function to perform inorder traversal on the tree
+    private static void visitInorderIterative(FormulaAST node, FormulaASTVisitor visitor, FormulaProperties properties) throws FormulaException{
+        Stack<FormulaAST> stack = new Stack<>();
+        FormulaAST curr = node;
+        while (curr != null || !stack.isEmpty()) {
+            while (curr != null) {
+                stack.push(curr);
+                curr = (FormulaAST)curr.getFirstChild();
+            }
+            curr = stack.pop();
+            try{
+                visitor.visit(curr);
+            }catch (FormulaException x){
+                handleVisitExceptions(x, node, visitor, properties);
+            }
+            curr = (FormulaAST)curr.getNextSibling();
         }
     }
 

--- a/impl/src/test/java/com/force/formula/BaseFormulaInfoImplTest.java
+++ b/impl/src/test/java/com/force/formula/BaseFormulaInfoImplTest.java
@@ -1,0 +1,188 @@
+package com.force.formula;
+
+import com.force.formula.impl.BaseFormulaInfoImpl;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaASTVisitor;
+import com.force.formula.impl.FormulaUtils;
+import com.force.formula.parser.gen.FormulaTokenTypes;
+import junit.framework.TestCase;
+
+import java.util.*;
+
+public class BaseFormulaInfoImplTest extends TestCase {
+
+    //Test for Labels which are treated as templates and are defined in a linear way
+    public void testVisit1() throws Exception{
+
+        final List<String> actualOutput = new ArrayList<>();
+        FormulaASTVisitor visitor = new FormulaASTVisitor() {
+            @Override
+            public void visit(FormulaAST node) throws FormulaException {
+                if (node.getType() == FormulaTokenTypes.IDENT) {
+                    actualOutput.add(node.getText());
+                }
+            }
+        };
+        FormulaProperties properties = new FormulaProperties();
+        properties.setParseAsTemplate(true);
+
+        //Testcase 1: source is empty (source can never be null)
+        String source1 = "";
+        List<String> expectedOutput1 = Collections.emptyList();
+        FormulaAST ast1 = FormulaUtils.parse(source1,properties);
+
+        //Testcase 2: source has 1 Label
+        String source2 = "{!$Label.a}";
+        List<String> expectedOutput2 = Arrays.asList("$Label.a");
+        FormulaAST ast2 = FormulaUtils.parse(source2,properties);
+
+        //Testcase 3: source has multiple Labels
+        String source3 = "\n" +
+                "    {!$Label.a}\n" +
+                "    {!$Label.b}\n" +
+                "    {!$Label.c}\n" +
+                "    {!$Label.d}";
+        List<String> expectedOutput3 = Arrays.asList("$Label.a",
+                "$Label.b",
+                "$Label.c",
+                "$Label.d");
+        FormulaAST ast3 = FormulaUtils.parse(source3,properties);
+
+        BaseFormulaInfoImpl.visit(ast1,visitor,properties);
+        assertEquals(actualOutput,expectedOutput1);
+
+        actualOutput.clear();
+
+        BaseFormulaInfoImpl.visit(ast2,visitor,properties);
+        assertEquals(actualOutput,expectedOutput2);
+
+        actualOutput.clear();
+
+        BaseFormulaInfoImpl.visit(ast3,visitor,properties);
+        assertEquals(actualOutput,expectedOutput3);
+
+        actualOutput.clear();
+    }
+
+    //Test if the AST is visited in-order manner by BaseFormulaInfoImpl.visit()
+    public void testVisit0() throws Exception{
+        FormulaProperties properties = new FormulaProperties();
+        final List<String> actualOutput = new ArrayList<>();
+        FormulaASTVisitor visitor = new FormulaASTVisitor() {
+            @Override
+            public void visit(FormulaAST node) throws FormulaException {
+                if (node.getType() == FormulaTokenTypes.NUMBER) {
+                    actualOutput.add(node.getText());
+                }
+            }
+        };
+        //Testcase 1: when root of AST is null
+        FormulaAST ast1 = constructTestAST(null);
+        BaseFormulaInfoImpl.visit(ast1, visitor, properties);
+        assertEquals(Collections.EMPTY_LIST,actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 2: when root of AST has 1 node
+        FormulaAST ast2 = constructTestAST("1");
+        BaseFormulaInfoImpl.visit(ast2, visitor, properties);
+        assertEquals(Arrays.asList("1"), actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 3: when root of AST has 3 node like shown below
+        FormulaAST ast3 = constructTestAST("1,2,3");
+        /*
+                   1
+                 /   \
+                2     3
+         */
+        BaseFormulaInfoImpl.visit(ast3, visitor, properties);
+        assertEquals(Arrays.asList("2","1","3"), actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 4: when root of AST has 3 node like shown below
+        FormulaAST ast4 = constructTestAST("1,null,2,null,3");
+        /*
+                   1
+                    \
+                     2
+                      \
+                       3
+         */
+        BaseFormulaInfoImpl.visit(ast4, visitor, properties);
+        assertEquals(Arrays.asList("1","2","3"), actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 5: when root of AST has 3 node like shown below
+        FormulaAST ast5 = constructTestAST("1,null,2,3,null");
+        /*
+                   1
+                    \
+                     2
+                    /
+                   3
+         */
+        BaseFormulaInfoImpl.visit(ast5, visitor, properties);
+        assertEquals(Arrays.asList("1","3","2"), actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 6: when root of AST has 3 node like shown below
+        FormulaAST ast6 = constructTestAST("1,2,null,3,null");
+        /*
+                   1
+                  /
+                 2
+                /
+               3
+         */
+        BaseFormulaInfoImpl.visit(ast6, visitor, properties);
+        assertEquals(Arrays.asList("3","2","1"), actualOutput);
+
+        actualOutput.clear();
+
+        //Testcase 7: when root of AST has 3 node like shown below
+        FormulaAST ast7 = constructTestAST("1,2,null,null,3");
+        /*
+                   1
+                  /
+                 2
+                  \
+                   3
+         */
+        BaseFormulaInfoImpl.visit(ast7, visitor, properties);
+        assertEquals(Arrays.asList("2","3","1"), actualOutput);
+
+    }
+
+    //The input represents the serialized format of a binary tree using level order traversal,
+    // where null signifies a path terminator where no node exists below.
+    private FormulaAST constructTestAST(String data){
+        if(data==null || data=="" || data.equals("null")) return null;
+        String[] list = data.split(",");
+        FormulaAST root = new FormulaAST(list[0]);
+        root.setType(FormulaTokenTypes.NUMBER);
+        List<FormulaAST> queue = new ArrayList<>();
+        queue.add(root);
+        for(int i=1;i<list.length;i++){
+            FormulaAST parent = queue.remove(0);
+            parent.setType(FormulaTokenTypes.NUMBER);
+            if(!list[i].equals("null")){
+                FormulaAST left = new FormulaAST(list[i]);
+                left.setType(FormulaTokenTypes.NUMBER);
+                parent.setFirstChild(left);
+                queue.add(left);
+            }
+            if(!list[++i].equals("null")){
+                FormulaAST right = new FormulaAST(list[i]);
+                right.setType(FormulaTokenTypes.NUMBER);
+                parent.setNextSibling(right);
+                queue.add(right);
+            }
+        }
+        return root;
+    }
+}


### PR DESCRIPTION
There were StackOverFlow errors happening due to recursive implementation of BaseFormulaInfoImpl.visit() whenever a list containing even 1000 Labels(templates) is passed as a single string because the AST generated in those scenarios would be skewed and makes around 3000 recursive calls to visit(). Moving to iterative implementation would free up the limited program stack space for such scenarios and avoid StackOverflow errors.