### PR TITLE
Fix Javascript AddMonths to match new behavior

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
@@ -18,6 +18,7 @@ import com.force.formula.FormulaException;
 import com.force.formula.FormulaProperties;
 import com.force.formula.FormulaRuntimeContext;
 import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaValidationHooks;
 import com.force.formula.impl.IllegalArgumentTypeException;
 import com.force.formula.impl.JsValue;
 import com.force.formula.impl.TableAliasRegistry;
@@ -73,7 +74,7 @@ public class FunctionAddMonths extends FormulaCommandInfoImpl implements Formula
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         String js =  "$F.addmonths(" + args[0] + "," + jsToNum(context, args[1].js) + ")";
-        return JsValue.generate(js, args, true, args[0]);
+        return JsValue.generate(js, args, true, args);
     }
 
     /**
@@ -105,7 +106,7 @@ public class FunctionAddMonths extends FormulaCommandInfoImpl implements Formula
             if (d == null) {
             	result = null;  // No NPEs if null
             } else if (months == null) {
-            	result = input; // Assume null = 0 months?
+            	result = FormulaValidationHooks.get().functionHook_addNullMonthsAsZero() ? d : null; // match behavior of sql.
             } else {
                 Calendar c = FormulaI18nUtils.getLocalizer().getCalendar(BaseLocalizer.GMT);
                 c.setTime(d);

--- a/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
@@ -649,6 +649,15 @@ public interface FormulaValidationHooks extends FormulaEngineHooks {
         return null;
     }
     
+    
+    /**
+     * @return whether java & javascript should treat null months in ADDMONTHS() as zero, 
+     * and return the passed in date if true.  Defaults to false, which returns null.
+     */
+    default boolean functionHook_addNullMonthsAsZero() {
+        return false;
+    }
+    
     /**
      * Encode the given string as a URL for use in embedding in a template.  If you do not want to do URL encoding, 
      * override to just return string.

--- a/impl/src/test/goldfiles/FormulaFields/testAddMonths.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testAddMonths.xml
@@ -10,19 +10,19 @@
        <Guard>null</Guard>
     </SqlOutput>
     <JsOutput highPrec="true" nullAsNull="false">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),$F.nvl(context.record.customnumber1__c,new $F.Decimal('0')).toNumber())):null</JsOutput>
-    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),context.record.customnumber1__c.toNumber())):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),context.record.customnumber1__c.toNumber())):null</JsOutput>
     <JsOutput highPrec="false" nullAsNull="false">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),$F.nvl(context.record.customnumber1__c,0))):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),context.record.customnumber1__c)):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT'))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(context.record.customdate1__c + ' GMT')),context.record.customnumber1__c)):null</JsOutput>
       <result>
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 11:32:00 GMT 2004</formula>
          <sql>2004-12-31 11:32:00.0</sql>
          <javascript>Fri Dec 31 11:32:00 GMT 2004</javascript>
          <javascriptLp>Fri Dec 31 11:32:00 GMT 2004</javascriptLp>
-         <formulaNullAsNull>Fri Dec 31 11:32:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
-         <javascriptNullAsNull>Error: TypeError: Cannot read property 'toNumber' of null</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Fri Dec 31 11:32:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>null</javascriptNullAsNull>
+         <javascriptLpNullAsNull>null</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:12:31:11:32:00, -12.00]</inputvalues>
@@ -413,12 +413,12 @@
       <inputvalues>[2004:03:30:07:34:00:GMT, -1.00]</inputvalues>
          <formula>Sun Feb 29 07:34:00 GMT 2004</formula>
          <sql>2004-02-29 07:34:00.0</sql>
-         <javascript>Mon Mar 01 07:34:00 GMT 2004</javascript>
-         <javascriptLp>Mon Mar 01 07:34:00 GMT 2004</javascriptLp>
+         <javascript>Sun Feb 29 07:34:00 GMT 2004</javascript>
+         <javascriptLp>Sun Feb 29 07:34:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Sun Feb 29 07:34:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-02-29 07:34:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Mon Mar 01 07:34:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Mon Mar 01 07:34:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Sun Feb 29 07:34:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:30:07:34:00:GMT, 1.00]</inputvalues>

--- a/impl/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
@@ -10,19 +10,19 @@
        <Guard>null</Guard>
     </SqlOutput>
     <JsOutput highPrec="true" nullAsNull="false">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),$F.nvl(context.record.customnumber1__c,new $F.Decimal('0')).toNumber())):null</JsOutput>
-    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),context.record.customnumber1__c.toNumber())):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),context.record.customnumber1__c.toNumber())):null</JsOutput>
     <JsOutput highPrec="false" nullAsNull="false">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),$F.nvl(context.record.customnumber1__c,0))):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),context.record.customnumber1__c)):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0)))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdate1__c])?null:new Date(new Date(context.record.customdate1__c).setUTCHours(0,0,0,0))),context.record.customnumber1__c)):null</JsOutput>
       <result>
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 00:00:00 GMT 2004</formula>
          <sql>2004-12-31 00:00:00.0</sql>
          <javascript>Fri Dec 31 00:00:00 GMT 2004</javascript>
          <javascriptLp>Fri Dec 31 00:00:00 GMT 2004</javascriptLp>
-         <formulaNullAsNull>Fri Dec 31 00:00:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
-         <javascriptNullAsNull>Error: TypeError: Cannot read property 'toNumber' of null</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Fri Dec 31 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>null</javascriptNullAsNull>
+         <javascriptLpNullAsNull>null</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:12:31:11:32:00, -12.00]</inputvalues>
@@ -410,16 +410,15 @@
          <javascriptLpNullAsNull>Wed Mar 30 00:00:00 GMT 2005</javascriptLpNullAsNull>
       </result>
       <result>
-      <!-- Test Case results don't match: viaFormula Sun Feb 29 00:00:00 GMT 2004 does not equal viaJavascript Mon Mar 01 00:00:00 GMT 2004 -->
       <inputvalues>[2004:03:30:07:34:00:GMT, -1.00]</inputvalues>
          <formula>Sun Feb 29 00:00:00 GMT 2004</formula>
          <sql>2004-02-29 00:00:00.0</sql>
-         <javascript>Mon Mar 01 00:00:00 GMT 2004</javascript>
-         <javascriptLp>Mon Mar 01 00:00:00 GMT 2004</javascriptLp>
+         <javascript>Sun Feb 29 00:00:00 GMT 2004</javascript>
+         <javascriptLp>Sun Feb 29 00:00:00 GMT 2004</javascriptLp>
          <formulaNullAsNull>Sun Feb 29 00:00:00 GMT 2004</formulaNullAsNull>
          <sqlNullAsNull>2004-02-29 00:00:00.0</sqlNullAsNull>
-         <javascriptNullAsNull>Mon Mar 01 00:00:00 GMT 2004</javascriptNullAsNull>
-         <javascriptLpNullAsNull>Mon Mar 01 00:00:00 GMT 2004</javascriptLpNullAsNull>
+         <javascriptNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Sun Feb 29 00:00:00 GMT 2004</javascriptLpNullAsNull>
       </result>
       <result>
       <inputvalues>[2004:03:30:07:34:00:GMT, 1.00]</inputvalues>

--- a/impl/src/test/goldfiles/FormulaFields/testAddMonthsDateTime.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testAddMonthsDateTime.xml
@@ -10,9 +10,9 @@
        <Guard>null</Guard>
     </SqlOutput>
     <JsOutput highPrec="true" nullAsNull="false">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),$F.nvl(context.record.customnumber1__c,new $F.Decimal('0')).toNumber())):null</JsOutput>
-    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),context.record.customnumber1__c.toNumber())):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),context.record.customnumber1__c.toNumber())):null</JsOutput>
     <JsOutput highPrec="false" nullAsNull="false">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),$F.nvl(context.record.customnumber1__c,0))):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),context.record.customnumber1__c)):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT'))!=null&amp;&amp;context.record.customnumber1__c!=null)?($F.addmonths(($F.anl([context.record.customdatetime1__c])?null:new Date(context.record.customdatetime1__c + ' GMT')),context.record.customnumber1__c)):null</JsOutput>
       <result>
       <inputvalues>[2004:12:31:11:32:00, 3.00]</inputvalues>
          <formula>Thu Mar 31 11:32:00 GMT 2005</formula>

--- a/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
+++ b/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
@@ -50,31 +50,4 @@ public class BuiltinFunctionsJsTest extends BuiltinFunctionsTest {
     @Override
     public void testRPAD() throws Exception {}
 
-    @Override
-    // This test should be removed once the javascript bug is fixed
-    public void testADDMONTHS() throws Exception {
-        // last day of the month
-        assertEquals(evaluateDate("date(2020, 2, 29)"), evaluateDate("ADDMONTHS(date(2020, 1, 31), 1)"));
-        assertEquals(evaluateDate("date(2020, 7, 31)"), evaluateDate("ADDMONTHS(date(2020, 4, 30), 3)"));
-        assertEquals(evaluateDate("date(2019, 1, 31)"), evaluateDate("ADDMONTHS(date(2019, 2, 28), -1)"));
-        assertEquals(evaluateDate("date(2020, 4, 30)"), evaluateDate("ADDMONTHS(date(2020, 7, 31), -3)"));
-        evaluateDate("ADDMONTHS(date(2019, 1, 30), 1)");
-        // day greater than the max day of the resulting month
-        // javascript bug:
-        //    evaluateDate("ADDMONTHS(date(2020, 1, 30), 1)") ==> Sun Mar 01 00:00:00 GMT 2020
-        //    evaluateDate("ADDMONTHS(date(2020, 5, 30), -3)") ==> Sun Mar 01 00:00:00 GMT 2020
-        //
-        // comment out this for now in order to avoid build failure
-        // assertEquals(evaluateDate("date(2020, 2, 29)"), evaluateDate("ADDMONTHS(date(2020, 1, 30), 1)"));
-        // assertEquals(evaluateDate("date(2020, 2, 29)"), evaluateDate("ADDMONTHS(date(2020, 5, 30), -3)"));
-
-        // day not fewer than the max day of the resulting month
-        assertEquals(evaluateDate("date(2020, 2, 25)"), evaluateDate("ADDMONTHS(date(2020, 1, 25), 1)"));
-        assertEquals(evaluateDate("date(2020, 2, 10)"), evaluateDate("ADDMONTHS(date(2020, 5, 10), -3)"));
-
-        // fractional month
-        assertEquals(evaluateDate("date(2020, 1, 25)"), evaluateDate("ADDMONTHS(date(2020, 1, 25), 0.5)"));
-        assertEquals(evaluateDate("date(2020, 2, 29)"), evaluateDate("ADDMONTHS(date(2020, 2, 29), -0.8)"));
-    }
-
 }

--- a/impl/src/test/java/com/force/formula/impl/TestExtendedFormulas.java
+++ b/impl/src/test/java/com/force/formula/impl/TestExtendedFormulas.java
@@ -48,10 +48,6 @@ public class TestExtendedFormulas extends FormulaPostgreSQLTests {
 			// TODO: Implement distance functions in Javascript
 			return true;
 		}
-		if ("testAddMonthsDate".equals(testName)) {
-			// TODO: AddMonths in javascript doesn't handle leap year + daylight savings + last day of month.
-			return true;
-		}
 		if ("testFormatCurrency".equals(testName)) {
 			// TODO: The negative sign shows up in front of the code in javascript.  
 			// "-USD 100.00" instead of "USD -100.00"

--- a/impl/src/test/resources/com/force/formula/impl/formulatests.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulatests.xml
@@ -401,14 +401,9 @@ author: Srikanth Yendluri/Doug Chasman
          <referencefield devName="customnumber1" labelName="customnumber1"
              dataType="Double" scale="2" precision="12"/>
      </testcase>
-     <!-- AddMonths doesn't work right around leap years with dateonlys in Javascript... 
-            // TODO: AddMonths in Oracle has different behavior from Postgres for leap days.
-            // @see https://docs.oracle.com/cd/B19306_01/server.102/b14200/functions004.htm
-            // "If date is the last day of the month or if the resulting month has fewer days than the 
-            //      day component of date, then the result is the last day of the resulting month. " -->
      <testcase name="testAddMonths" devName="testAddMonths" labels="extended"
          labelName="testAddMonths" dataType="DateTime" dataFile="addMonths" 
-         whyIgnoreSql="oracle:Leap day support,mysql:leap day,mariadb:leap day,mssql: leap day"
+         whyIgnoreSql="mysql:leap day,mariadb:leap day,mssql: leap day"
          scale="2" precision="12" code="ADDMONTHS(customdate1__c,customnumber1__c)">
          <referencefield devName="customdate1" labelName="customdate1"
              dataType="DateTime"/>
@@ -417,7 +412,7 @@ author: Srikanth Yendluri/Doug Chasman
      </testcase>
      <testcase name="testAddMonthsDate" devName="testAddMonthsDate" labels="extended"
          labelName="testAddMonthsDate" dataType="DateOnly" dataFile="addMonths" 
-         whyIgnoreSql="oracle:Leap day support,mysql:leap day,mariadb:leap day,mssql: leap day"
+         whyIgnoreSql="mysql:leap day,mariadb:leap day,mssql: leap day"
          scale="2" precision="12" code="ADDMONTHS(customdate1__c,customnumber1__c)">
          <referencefield devName="customdate1" labelName="customdate1"
              dataType="DateOnly"/>
@@ -486,7 +481,7 @@ author: Srikanth Yendluri/Doug Chasman
      <testcase name="testAddMonthsDateTime" devName="testAddMonthsDateTime"
          labelName="testAddMonthsDateTime" dataType="DateTime" dataFile="addDateTime"
          scale="2" precision="12"  
-         whyIgnoreSql="postgres:TODO psql fractional day support differs from java,mysql:leap day,mariad:leap day,mssql:leap day"
+         whyIgnoreSql="mysql:leap day,mariad:leap day,mssql:leap day"
          code="ADDMONTHS(customdatetime1__c,customnumber1__c)">
          <referencefield devName="customdatetime1" labelName="customdatetime1"
              dataType="DateTime"/>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testAddMonths.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testAddMonths.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 11:32:00 GMT 2004</formula>
          <sql>2004-12-31 11:32:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 11:32:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testAddMonthsDate.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testAddMonthsDate.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 00:00:00 GMT 2004</formula>
          <sql>2004-12-31 00:00:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 00:00:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testAddMonths.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testAddMonths.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 11:32:00 GMT 2004</formula>
          <sql>2004-12-31 11:32:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 11:32:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 00:00:00 GMT 2004</formula>
          <sql>2004-12-31 00:00:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 00:00:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testAddMonths.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testAddMonths.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 11:32:00 GMT 2004</formula>
          <sql>2004-12-31 11:32:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 11:32:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testAddMonthsDate.xml
@@ -13,7 +13,7 @@
       <inputvalues>[2004:12:31:11:32:00, NULL]</inputvalues>
          <formula>Fri Dec 31 00:00:00 GMT 2004</formula>
          <sql>2004-12-31 00:00:00.0</sql>
-         <formulaNullAsNull>Fri Dec 31 00:00:00 GMT 2004</formulaNullAsNull>
+         <formulaNullAsNull>null</formulaNullAsNull>
          <sqlNullAsNull>null</sqlNullAsNull>
       </result>
       <result>

--- a/test-utils/src/main/java/com/force/formula/commands/FormulaJsTestUtils.java
+++ b/test-utils/src/main/java/com/force/formula/commands/FormulaJsTestUtils.java
@@ -165,11 +165,15 @@ public class FormulaJsTestUtils {
                         + "return String(value);};")
                 
                 
-                // Note, these add months does what java does, but may not do what oracle/postgres does
+                // Note, Javascript setMonths has strange behavior since it'll make January 30th + 1 month may be March.  And last day needs to remain last day to match oracle.
+                // So if it's the last day of the month, we add one to the day and add the month, then remove the day.  Otherwise we use the "set Date to 0 to be last day of previous month" javascript behavior 
+                // so Jan 30 + 1 month will be Feb 28 in a non-leap year 
+                .append("$F.addmonths=function(a,b) {if (a==null||b==null) return null;if (!b) return a;var lastDay=a.getUTCDay()==(new Date(Date.UTC(a.getUTCFullYear(),a.getUTCMonth()+1,0))).getUTCDay();"
+                        +"var d=new Date(a.getTime()+(lastDay?86400000:0));d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));"
+                        +"if (lastDay) return new Date(d.getTime()-86400000); if (d.getUTCDate()!=a.getUTCDate()){d.setUTCDate(0)};return d;};")
                 
-                .append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));return new Date(d.getTime()-86400000);};\n")
                 // Use this if you want to support fractional dates
-        		//.append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));d.setUTCDate(d.getUTCDate()+Math.trunc((b%1)*365.24/12));return new Date(d.getTime()-86400000);};");
+        		//.append("$F.addmonths=function(a,b) {if (a==null||!b) return a;var d=new Date(a.getTime()+86400000);d.setUTCMonth(d.getUTCMonth()+Math.trunc(b));d.setUTCDate(d.getUTCDate()+Math.trunc((b%1)*365.24/12));return new Date(d.getTime()-86400000);};")
 
                 // ISO week/day functions
         		.append("$F.isoweek=function(a) {if (!a) return a;"


### PR DESCRIPTION
Javascript AddMonths needs special "if last day" logic to match oracle/postgres
Have java and javascript return null if the number of months to add is null to match the DB (Behavior Change, but in a hook).
Remove ignoring addMonths from postgres in tests