### PR TITLE
@W-11654516 - Register IFS

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/FormulaCommandTypeRegistryImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaCommandTypeRegistryImpl.java
@@ -33,6 +33,7 @@ import com.force.formula.commands.FunctionFloor;
 import com.force.formula.commands.FunctionGeolocation;
 import com.force.formula.commands.FunctionHour;
 import com.force.formula.commands.FunctionIf;
+import com.force.formula.commands.FunctionIfs;
 import com.force.formula.commands.FunctionIsBlank;
 import com.force.formula.commands.FunctionIsClone;
 import com.force.formula.commands.FunctionIsNew;
@@ -227,6 +228,7 @@ public class FormulaCommandTypeRegistryImpl implements FormulaCommandTypeRegistr
         types.add(new FunctionDatetimeValue());
         types.add(new FunctionIsNew());
         types.add(new FunctionIsClone());
+        types.add(new FunctionIfs());
 
         DEFAULT_COMMANDS = ImmutableList.copyOf(types);
     }

--- a/impl/src/test/java/com/force/formula/impl/BaseCustomizableParserTest.java
+++ b/impl/src/test/java/com/force/formula/impl/BaseCustomizableParserTest.java
@@ -43,7 +43,6 @@ import com.force.formula.commands.FunctionFormatCurrency;
 import com.force.formula.commands.FunctionFormatDuration;
 import com.force.formula.commands.FunctionFromUnixTime;
 import com.force.formula.commands.FunctionIfError;
-import com.force.formula.commands.FunctionIfs;
 import com.force.formula.commands.FunctionInitCap;
 import com.force.formula.commands.FunctionIsChanged;
 import com.force.formula.commands.FunctionIsPickVal;
@@ -169,7 +168,7 @@ public abstract class BaseCustomizableParserTest extends ParserTestBase {
         types.add(new FieldReferenceCommandInfo());
         types.add(new DynamicReference());
         types.add(new FunctionIfError());
-        types.add(new FunctionIfs());
+        //types.add(new FunctionIfs());
         types.add(new FunctionDistance());
         types.add(new FunctionIsChanged());
         types.add(new FunctionIsPickVal());


### PR DESCRIPTION
-Registering IFS in FormulaCommandTypeRegistryImpl
-Remove the IFS from CustomizableParserTest since it is already loaded from the registry.