### PR TITLE
Fix AST node argument to handleVisitException()

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -709,7 +709,7 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
             try{
                 visitor.visit(curr);
             }catch (FormulaException x){
-                handleVisitExceptions(x, node, visitor, properties);
+                handleVisitExceptions(x, curr, visitor, properties);
             }
             curr = (FormulaAST)curr.getNextSibling();
         }


### PR DESCRIPTION
handleVisitException() expects the current AST node in its argument instead of the root AST node. Missed this while changing the implementation of visit() from recursive to iterative.