### PR TITLE
Fix getFailOnEmbeddedFormulaExceptions change

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/impl/BaseFormulaInfoImpl.java
@@ -6,16 +6,50 @@ package com.force.formula.impl;
 
 import java.lang.reflect.Type;
 import java.math.BigDecimal;
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Date;
+import java.util.Deque;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Matcher;
 
-import com.force.formula.*;
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.Formula;
+import com.force.formula.FormulaCommand;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaFieldInfo;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaProvider;
+import com.force.formula.FormulaReturnType;
+import com.force.formula.FormulaRuntimeContext;
 import com.force.formula.FormulaRuntimeContext.InaccessibleFieldStrategy;
-import com.force.formula.commands.*;
+import com.force.formula.FormulaSchema;
+import com.force.formula.FormulaTime;
+import com.force.formula.FormulaTooLongException;
+import com.force.formula.FormulaTypeWithDomain;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.JSTooBigException;
+import com.force.formula.RuntimeFormulaInfo;
+import com.force.formula.commands.ConstantNull;
+import com.force.formula.commands.FormulaCommandEnricher;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoRegistry;
+import com.force.formula.commands.FormulaCommandOptimizer;
+import com.force.formula.commands.RuntimeType;
 import com.force.formula.impl.FormulaCommandVisitorImpl.FormatCurrencyVisitor;
 import com.force.formula.parser.gen.FormulaTokenTypes;
-import com.force.formula.sql.*;
+import com.force.formula.sql.FormulaWithSql;
+import com.force.formula.sql.InvalidFormula;
+import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.formula.util.FormulaTextUtil;
 import com.google.common.base.Joiner;
@@ -685,7 +719,7 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
         FormulaCommandInfo commandInfo = FormulaCommandInfoRegistry.get(ast);
         return commandInfo.getJavascript(ast, context, args);
     }
-
+    
     public static void visit(FormulaAST node, FormulaASTVisitor visitor, FormulaProperties properties)
             throws FormulaException {
         /**
@@ -717,10 +751,8 @@ public abstract class BaseFormulaInfoImpl implements RuntimeFormulaInfo {
 
     private static void handleVisitExceptions(FormulaException x, FormulaAST node, FormulaASTVisitor visitor,
         FormulaProperties properties) throws FormulaException {
-        // Let the exception propogate if we are configured to throw exceptions on embedded formula exceptions or we're not the top of the AST tree
-        boolean isTopLevelInTemplate = FormulaAST.isTopOfTemplateExpression(node);
-        if (!properties.getParseAsTemplate() || properties.getFailOnEmbeddedFormulaExceptions()
-            || !isTopLevelInTemplate) {
+        // Let the exception propogate if we are configured to throw exceptions on embedded formula exceptions 
+        if (!properties.getParseAsTemplate() || properties.getFailOnEmbeddedFormulaExceptions()) {
             if (x instanceof InvalidFieldReferenceException) {
                 InvalidFieldReferenceException ifre = (InvalidFieldReferenceException) x;
                 if (ifre.getLocation() < 0) {

--- a/impl/src/test/java/com/force/formula/template/commands/TemplateOptionsTest.java
+++ b/impl/src/test/java/com/force/formula/template/commands/TemplateOptionsTest.java
@@ -1,0 +1,96 @@
+/**
+ * 
+ */
+package com.force.formula.template.commands;
+
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.MockFormulaDataType;
+import com.force.formula.MockFormulaType;
+import com.force.formula.impl.BaseCustomizableParserTest;
+import com.force.formula.impl.FormulaInfoFactory;
+import com.force.formula.impl.FormulaParseException;
+import com.force.formula.sql.RuntimeSqlFormulaInfo;
+
+/**
+ * Test of various error handling permutations of template processing.
+ *
+ * @author stamm
+ * @since 0.2.16
+ */
+public class TemplateOptionsTest extends BaseCustomizableParserTest {
+
+    public TemplateOptionsTest(String name) {
+        super(name);
+    }
+    
+    @Override
+    protected MockFormulaType getFormulaType() {
+        return MockFormulaType.TEMPLATE;
+    }
+    
+    public void testInvalidEmbeddedFormulaExpressions() throws Exception {
+        FormulaRuntimeContext context = setupMockContext(MockFormulaDataType.TEXT);
+
+        String message = "{!x} {! \"Some ok \" & \"stuff\"} {! y + x } followed by lexical garbage {!1 % 1 } and finally more garbage {! with another crap expression}";
+
+        FormulaProperties properties = new FormulaProperties();
+        properties.setGenerateSQL(false);
+        properties.setAllowCycles(false);
+        properties.setPolymorphicReturnType(true);
+        properties.setParseAsTemplate(true);
+        properties.setFailOnEmbeddedFormulaExceptions(true);
+        properties.setThrowOnUnavailableField(true);
+
+        try {
+            FormulaInfoFactory.create(context, message, properties);
+            fail("Should fail");
+        } catch (FormulaParseException ex) {
+            assertEquals("Syntax error", ex.getMessage());
+        }
+
+        // Invalid Field Reference should propogate
+        try {
+            FormulaInfoFactory.create(context, "Far {!x}", properties);
+            fail("Should fail");
+        } catch (InvalidFieldReferenceException ex) {
+            assertEquals("Field x does not exist. Check spelling.", ex.getMessage());
+            assertEquals(7, ex.getLocation());
+        }
+
+        properties.setThrowOnUnavailableField(false);
+        try {
+            FormulaInfoFactory.create(context, message, properties);
+            fail("Should fail");
+        } catch (FormulaParseException ex) {
+            assertEquals("Syntax error", ex.getMessage());
+        }
+        
+        try {
+            FormulaInfoFactory.create(context, "{!garbage test}", properties);
+            fail("Should fail");
+        } catch (FormulaParseException ex) {
+            assertEquals("Syntax error. Extra test", ex.getMessage());
+        }
+
+
+        // Turn failing off, and it should work with 'null' for the bad values.
+        properties.setFailOnEmbeddedFormulaExceptions(false);
+
+        RuntimeSqlFormulaInfo fi = FormulaInfoFactory.create(context, message, properties);
+        assertEquals("null Some ok stuff null followed by lexical garbage null and finally more garbage null", fi.getFormula().evaluate(context));
+        
+        // Fail on Embedded controls it.
+        properties.setThrowOnUnavailableField(true);
+        fi = FormulaInfoFactory.create(context, message, properties);
+        assertEquals("null Some ok stuff null followed by lexical garbage null and finally more garbage null", fi.getFormula().evaluate(context));
+        
+        // Test stufff
+        fi = FormulaInfoFactory.create(context, "{!garbage test}", properties);
+        assertEquals("null", fi.getFormula().evaluate(context));
+        fi = FormulaInfoFactory.create(context, "{!1 % 1}", properties);
+        assertEquals("null", fi.getFormula().evaluate(context));
+        
+    }
+}

--- a/test-utils/src/main/java/com/force/formula/MockFormulaContext.java
+++ b/test-utils/src/main/java/com/force/formula/MockFormulaContext.java
@@ -46,6 +46,12 @@ public class MockFormulaContext extends NullFormulaContext {
     public String getName() {
         throw new UnsupportedOperationException();
     }
+    
+    @Override
+    public ContextualFormulaFieldInfo lookup(String fieldName, boolean isDynamicRefBase)
+            throws InvalidFieldReferenceException, UnsupportedTypeException {
+        throw new InvalidFieldReferenceException(fieldName, "UNSUPPORTED");
+    }
 
     @Override
     public FormulaReturnType getFormulaReturnType() {


### PR DESCRIPTION
The check for "is top level" for template processing isn't needed since it
  when iterative because the exceptions don't propagate.  So remove the
  check for top level and add a test to validate the bhevaior is the same
@sahil-here