### PR TITLE
Template error handling type issue

### DIFF
--- a/impl/src/test/java/com/force/formula/template/commands/TemplateOptionsTest.java
+++ b/impl/src/test/java/com/force/formula/template/commands/TemplateOptionsTest.java
@@ -92,5 +92,9 @@ public class TemplateOptionsTest extends BaseCustomizableParserTest {
         fi = FormulaInfoFactory.create(context, "{!1 % 1}", properties);
         assertEquals("null", fi.getFormula().evaluate(context));
         
+        // Make sure the "top level" is nulled, not the inner value for exceptions.
+        fi = FormulaInfoFactory.create(context, "{!len(x)}", properties);
+        assertEquals("null", fi.getFormula().evaluate(context));
+        
     }
 }


### PR DESCRIPTION
When replacing a bad formula entry in a template, only the top-level should be a
  string.  The previous changes to make it in-order traversal replaced the erroring
  node with a String.  This change pops the stack back to the top of the
  template so you're not creating a different class cast exception with
  {!ABS(x)} having the type of 'x' incorrectly being a string

@sahil-here