### PR TITLE
Support REGEX function in javascript and sql

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,4 +40,7 @@ In order to implement this formula engine in your application, you need to
   DI frameworks like spring a problem.  
 * MySQL support assumes the database uses case insensitive collation (utf8_bin) to match other DBs.  If you're
   DB is case sensitive, there will be discrepancies between the DB and the Java/Javascript evalution.
+* Array and Map support doesn't translate to DB queries for DBs that support it
+* Not all functions are supported in all DBs.  Use a FunctionFilter, as level of support differs from throwing 
+  `UnsupportedOperationException` to minor differences in corner cases.
 

--- a/api/src/main/java/com/force/formula/FormulaCommandType.java
+++ b/api/src/main/java/com/force/formula/FormulaCommandType.java
@@ -3,7 +3,10 @@
  */
 package com.force.formula;
 
-import java.lang.annotation.*;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
  * Represents a Formula Command (i.e. an operator or formula function)
@@ -38,6 +41,8 @@ public interface FormulaCommandType {
         boolean isJavascript() default true;
 	    /** @return Is this function available in the offline context?  This means it has *the same behavior* as java and SQL.  Higher bar<br>Default: false **/
 	    boolean isOffline() default false;
+	    /** @return Is this function implemented in SQL */
+	    boolean isSql() default true;
 	    
 	    /** @return A customer defined access check variable to control access to formulas that aren't "public".  */
 	    String access() default "";

--- a/api/src/main/java/com/force/formula/FunctionFilter.java
+++ b/api/src/main/java/com/force/formula/FunctionFilter.java
@@ -8,6 +8,10 @@ package com.force.formula;
 @FunctionalInterface
 public interface FunctionFilter {
 
+    /**
+     * @param command the command type 
+     * @return whether or not this command is supported in this environment.
+     */
     boolean isSupported(FormulaCommandType command);
 
 }

--- a/google-test/src/test/goldfiles/FormulaFields/Spanner/testRegex.xml
+++ b/google-test/src/test/goldfiles/FormulaFields/Spanner/testRegex.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN REGEXP_CONTAINS(COALESCE($!s0s!$.customtext__c,''),COALESCE(COALESCE('^','')||COALESCE($!s0s!$.customexpr__c,''),'')||COALESCE('$','')) THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN REGEXP_CONTAINS(COALESCE($!s0s!$.customtext__c,''),COALESCE(COALESCE('^','')||COALESCE($!s0s!$.customexpr__c,''),'')||COALESCE('$','')) THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>Error: OUT_OF_RANGE: io.grpc.StatusRuntimeException: OUT_OF_RANGE: Cannot parse regular expression: missing ): ^(($ - Statement: 'SELECT SUBSTR(CASE WHEN REGEXP_CONTAINS(COALESCE(c.customtext__c,''),COALESCE(COALESCE('^','')||COALESCE(c.customexpr__c,''),'')||COALESCE('$','')) THEN 'TRUE' ELSE 'FALSE' END, 1, 1300) FROM (SELECT 1 as fake, @p1 as customexpr__c, @p2 as customtext__c) c'</sql>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>Error: OUT_OF_RANGE: io.grpc.StatusRuntimeException: OUT_OF_RANGE: Cannot parse regular expression: missing ): ^(($ - Statement: 'SELECT SUBSTR(CASE WHEN REGEXP_CONTAINS(COALESCE(c.customtext__c,''),COALESCE(COALESCE('^','')||COALESCE(c.customexpr__c,''),'')||COALESCE('$','')) THEN 'TRUE' ELSE 'FALSE' END, 1, 1300) FROM (SELECT 1 as fake, @p1 as customexpr__c, @p2 as customtext__c) c'</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/impl/src/main/java/com/force/formula/commands/FunctionFormat.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFormat.java
@@ -55,7 +55,7 @@ import com.force.i18n.Renameable;
  * @author stamm
  * @since 150
  */
-@AllowedContext(section=SelectorSection.DATE_TIME, access="beta",displayOnly=true, isJavascript=false)
+@AllowedContext(section=SelectorSection.DATE_TIME, access="beta",isSql=false,displayOnly=true, isJavascript=false)
 public class FunctionFormat extends FormulaCommandInfoImpl implements FormulaCommandValidator {
 
     public static final String LOCAL_TIME_CORRECT = "time_correct";

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsChanged.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsChanged.java
@@ -17,7 +17,7 @@ import com.force.formula.util.FormulaTextUtil;
  * @since 144
  */
 
-@AllowedContext(section=SelectorSection.ADVANCED, changeOnly=true, nonFlowOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.ADVANCED, isSql = false, changeOnly=true, nonFlowOnly=true,isJavascript=false)
 public class FunctionIsChanged extends FormulaCommandInfoImpl implements FormulaCommandValidator {
     public FunctionIsChanged() {
         super("ISCHANGED");

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsClone.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsClone.java
@@ -19,7 +19,7 @@ import com.force.formula.sql.SQLPair;
  * @author stamm
  * @since 198
  */
-@AllowedContext(section=SelectorSection.LOGICAL,changeOnly=true,nonFlowOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.LOGICAL,isSql = false, changeOnly=true,nonFlowOnly=true,isJavascript=false)
 public class FunctionIsClone extends FormulaCommandInfoImpl {
     public FunctionIsClone() {
         super("ISCLONE", Boolean.class, new Class[] {});

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsNew.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsNew.java
@@ -14,7 +14,7 @@ import com.force.formula.sql.SQLPair;
  * @author dchasman
  * @since 144
  */
-@AllowedContext(section=SelectorSection.LOGICAL,changeOnly=true,nonFlowOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.LOGICAL,isSql = false, changeOnly=true,nonFlowOnly=true,isJavascript=false)
 public class FunctionIsNew extends FormulaCommandInfoImpl {
     public FunctionIsNew() {
         super("ISNEW", Boolean.class, new Class[] {});

--- a/impl/src/main/java/com/force/formula/commands/FunctionLabel.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLabel.java
@@ -34,7 +34,7 @@ import com.google.common.base.Joiner;
  * @since 0.2.0
  * @see FunctionFormat
  */
-@AllowedContext(section=SelectorSection.TEXT,displayOnly=true)
+@AllowedContext(section=SelectorSection.TEXT,isSql=false,displayOnly=true)
 public class FunctionLabel extends FormulaCommandInfoImpl implements FormulaCommandValidator {
     public FunctionLabel() {
         // label constructor Section, Key.... plus optional arguments that will autorender with MessageFormat.

--- a/impl/src/main/java/com/force/formula/commands/FunctionPriorValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionPriorValue.java
@@ -17,7 +17,7 @@ import com.force.formula.sql.SQLPair;
  * @since 144
  */
 
-@AllowedContext(section=SelectorSection.LOGICAL,changeOnly=true,nonFlowOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.LOGICAL,isSql = false, changeOnly=true,nonFlowOnly=true,isJavascript=false)
 public class FunctionPriorValue extends FormulaCommandInfoImpl implements FormulaCommandValidator {
     public static final String OBJECT_TYPE_PREFIX = "$ObjectType";
     public static final String OBJECT_TYPE_PREFIX_UPPER = OBJECT_TYPE_PREFIX.toUpperCase(); // optimization to avoid repeated calls of toUpperCase()

--- a/impl/src/main/java/com/force/formula/impl/AnnotationVisitor.java
+++ b/impl/src/main/java/com/force/formula/impl/AnnotationVisitor.java
@@ -7,9 +7,17 @@ import java.lang.reflect.Type;
 import java.util.HashSet;
 import java.util.Set;
 
-import com.force.formula.*;
-import com.force.formula.commands.*;
-
+import com.force.formula.ContextualFormulaFieldInfo;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FunctionNotAllowedException;
+import com.force.formula.commands.FormulaCommandEnricher;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoRegistry;
+import com.force.formula.commands.FormulaCommandPrefetcher;
+import com.force.formula.commands.FormulaCommandValidator;
+import com.force.formula.commands.RuntimeType;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 
 /**
@@ -58,6 +66,10 @@ public class AnnotationVisitor implements FormulaASTVisitor {
         
         if (properties.getGenerateJavascript()
                 && !context.isFunctionSupportedOffline(commandInfo, node.getNumberOfChildren())) {
+            throw new FunctionNotAllowedException(commandInfo);
+        }
+        
+        if (properties.getGenerateSQL() && !commandInfo.getAllowedContext().isSql()) {
             throw new FunctionNotAllowedException(commandInfo);
         }
 

--- a/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
@@ -521,6 +521,15 @@ public interface FormulaSqlHooks extends FormulaSqlStyle {
     }
 
     /**
+     * @return how to perform a regular expression check where the text matches java pattern matching... 
+     * @param text the argument to validate
+     * @param regexp the argument that comprises the regular expression
+     */
+    default String sqlRegexpLike(String text, String regexp) {
+        return "REGEXP_LIKE(" + sqlNvl() + "(" + text + ",'')," + regexp + ")";
+    }
+    
+    /**
      * @return the formula for finding a substring in a string and returning the "position" 1-indexed.
      * In oracle and mysql, it's INSTR.
      * @param strArg the value of the string to search in

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
@@ -401,5 +401,10 @@ public interface FormulaGoogleHooks extends FormulaSqlHooks {
         sql.append("CONCAT(COALESCE(").append(isoCodeArg).append(",''),' ',FORMAT(").append(maskStr).append(',').append(amountArg).append("))");
     }
 
+    @Override
+    default String sqlRegexpLike(String text, String regexp) {
+        return "REGEXP_CONTAINS(COALESCE(" + text + ",'')," + regexp + ")";
+    }
+
     
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaPostgreSQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaPostgreSQLHooks.java
@@ -334,5 +334,9 @@ public interface FormulaPostgreSQLHooks extends FormulaSqlHooks {
         return argument+"::numeric(40,20)";   // Override to specify your own default precision.
     }
 
+    @Override
+    default String sqlRegexpLike(String text, String regexp) {
+        return "COALESCE(" + text + ",'') ~ " + regexp;
+    }
     
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaSqliteHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaSqliteHooks.java
@@ -470,6 +470,12 @@ public interface FormulaSqliteHooks extends FormulaSqlHooks {
         return "'" + FormulaDateUtil.formatDatetimeToSqlLiteral(c.getTime()) + "'";
     }
 
+    @Override
+    default String sqlRegexpLike(String text, String regexp) {
+        return text + " REGEXP " + regexp ;
+    }
+
+    
     /**
      * The Sqlite versions as of 2022 don't use the new Sqlite3 math functions, but instead custom ones
      * that break compatibility with old versions of sqlite.

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
@@ -452,5 +452,9 @@ public interface FormulaTransactSQLHooks extends FormulaSqlHooks {
         sql.append("CONCAT(").append(isoCodeArg).append(",' ',FORMAT(").append(amountArg).append(',').append(maskStr).append("))");
 	}
         
+    @Override
+    default String sqlRegexpLike(String text, String regexp) {
+        throw new UnsupportedOperationException("Regex Not Supported");
+    }
 
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
@@ -454,7 +454,8 @@ public interface FormulaTransactSQLHooks extends FormulaSqlHooks {
         
     @Override
     default String sqlRegexpLike(String text, String regexp) {
-        throw new UnsupportedOperationException("Regex Not Supported");
+        // Less intrusive than unsupported operation exception in java...
+        return "1=0";
     }
 
 }

--- a/impl/src/main/java/com/force/formula/template/commands/DynamicFieldSelector.java
+++ b/impl/src/main/java/com/force/formula/template/commands/DynamicFieldSelector.java
@@ -16,7 +16,7 @@ import com.force.formula.sql.SQLPair;
  * @author aballard
  * @since 168
  */
-@AllowedContext(section=SelectorSection.ADVANCED,isJavascript=false)
+@AllowedContext(section=SelectorSection.ADVANCED,isSql = false, isJavascript=false)
 public class DynamicFieldSelector extends FormulaCommandInfoImpl {
 
     public final static String DYNAMIC_REF_IDENT = FormulaCommandInfoRegistry.DYNAMIC_REF_IDENT; 

--- a/impl/src/main/java/com/force/formula/template/commands/DynamicReference.java
+++ b/impl/src/main/java/com/force/formula/template/commands/DynamicReference.java
@@ -25,7 +25,7 @@ import antlr.collections.AST;
  * @author aballard
  * @since 168
  */
-@AllowedContext(section=SelectorSection.ADVANCED,isJavascript=false)
+@AllowedContext(section=SelectorSection.ADVANCED,isSql = false, isJavascript=false)
 public class DynamicReference extends FormulaCommandInfoImpl implements FormulaCommandValidator {
 
     public final static String DYNAMIC_REF = FormulaCommandInfoRegistry.DYNAMIC_REF;

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionHtmlEncode.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionHtmlEncode.java
@@ -1,13 +1,15 @@
 package com.force.formula.template.commands;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
 import com.force.formula.commands.FormulaCommandInfo;
 import com.force.formula.impl.FormulaAST;
 import com.force.formula.util.FormulaTextUtil;
 
-@AllowedContext(section=SelectorSection.TEXT, displayOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.TEXT, isSql=false,displayOnly=true,isJavascript=false)
 public class FunctionHtmlEncode extends EncodingFunctionBase {
 
     public FunctionHtmlEncode() {

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionJSEncode.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionJSEncode.java
@@ -1,13 +1,15 @@
 package com.force.formula.template.commands;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
 import com.force.formula.commands.FormulaCommandInfo;
 import com.force.formula.impl.FormulaAST;
 import com.force.formula.util.FormulaTextUtil;
 
-@AllowedContext(section=SelectorSection.TEXT, displayOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.TEXT,isSql=false, displayOnly=true,isJavascript=false)
 public class FunctionJSEncode extends EncodingFunctionBase {
 
     public FunctionJSEncode() {

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionMap.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionMap.java
@@ -4,18 +4,25 @@ import java.lang.reflect.Type;
 import java.util.Deque;
 import java.util.LinkedHashMap;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.commands.*;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.commands.AbstractFormulaCommand;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoImpl;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
  * @author dchasman
  * @since 144
  */
-@AllowedContext(section=SelectorSection.ADVANCED, displayOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.ADVANCED,isSql=false, displayOnly=true,isJavascript=false)
 public class FunctionMap extends FormulaCommandInfoImpl {
 
     public static class StringToStringMap extends LinkedHashMap<String, String> {

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
@@ -4,17 +4,40 @@ import java.lang.reflect.Type;
 import java.util.Deque;
 import java.util.regex.Pattern;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.commands.*;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.commands.AbstractFormulaCommand;
+import com.force.formula.commands.ConstantString;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoImpl;
+import com.force.formula.commands.FormulaCommandValidator;
+import com.force.formula.commands.RuntimeType;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.IllegalArgumentTypeException;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.RegexTooComplicatedException;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.template.commands.AccessCountedCharSequence.AccessCountExceededException;
 
-@AllowedContext(section=SelectorSection.ADVANCED, changeOnly=true, isJavascript=false)
+/** 
+ * REGEX(Text, RegEx_Text)
+ * Returns TRUE if Text matches the regular expression RegEx_Text. Otherwise, it returns FALSE.
+ * Matches the entire string of Text, not just part, and null RegEx Text treated as "^$" and null
+ * Text treated as "".
+ */
+@AllowedContext(section=SelectorSection.ADVANCED, changeOnly=true)
 public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaCommandValidator {
+    // TODO: Move this limit to a hook or context variable.
     public static int FORMULA_LIMIT = 1000000; // limits the runtime to ~ 50ms on average machine
 
     public FunctionRegex() {
@@ -25,7 +48,7 @@ public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaComm
     public Class<?> validate(FormulaAST node, FormulaContext context, FormulaProperties properties)
         throws FormulaException {
         if (node.getNumberOfChildren() != 2) {
-            throw new WrongNumberOfArgumentsException(node.getText(), 1, node);
+            throw new WrongNumberOfArgumentsException(node.getText(), 2, node);
         }
 
         FormulaAST firstArg = (FormulaAST)node.getFirstChild();
@@ -58,12 +81,19 @@ public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaComm
     @Override
     public SQLPair getSQL(FormulaAST node, FormulaContext context, String[] args, String[] guards, TableAliasRegistry registry)
         throws FormulaException {
-        throw new UnsupportedOperationException();
+        FormulaSqlHooks hooks = getSqlHooks(context);
+        // Add in ^ and $ to force whole string matching.
+        String regex = String.format(hooks.sqlConcat(false), String.format(hooks.sqlConcat(false), "'^'", args[1]), "'$'");
+        String sql = hooks.sqlRegexpLike(args[0], regex);
+        String guard = SQLPair.generateGuard(guards, null);
+        return new SQLPair(sql, guard);
     }
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        throw new UnsupportedOperationException();
+        // If the regexp is null, it should be empty string test (i.e. '^$').  
+        String js = "new RegExp("+FormulaCommandInfoImpl.jsNvl2(args[1], "'^'+"+args[1].js+"+'$'", "'^$'")+").test("+FormulaCommandInfoImpl.jsNvl(args[0].js, "''")+")";
+        return JsValue.generate(js, args, false);
     }
 
 

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionTemplate.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionTemplate.java
@@ -5,11 +5,25 @@ import java.lang.reflect.Type;
 import java.util.Date;
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.commands.*;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.GenericFormulaException;
+import com.force.formula.commands.AbstractFormulaCommand;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoImpl;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaExceptionListener;
+import com.force.formula.impl.FormulaStack;
+import com.force.formula.impl.FormulaValidationHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.TemplateStaticMarkupString;
+import com.force.formula.impl.Thunk;
 import com.force.formula.sql.SQLPair;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.i18n.BaseLocalizer;
@@ -18,7 +32,7 @@ import com.force.i18n.BaseLocalizer;
  * @author dchasman
  * @since 144
  */
-@AllowedContext(section=SelectorSection.ADVANCED, displayOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.ADVANCED, isSql=false,displayOnly=true,isJavascript=false)
 public class FunctionTemplate extends FormulaCommandInfoImpl {
 
     public FunctionTemplate() {

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionUrlEncode.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionUrlEncode.java
@@ -3,15 +3,18 @@ package com.force.formula.template.commands;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaEvaluationException;
+import com.force.formula.FormulaException;
 import com.force.formula.commands.FormulaCommandInfo;
 import com.force.formula.impl.FormulaAST;
 import com.force.formula.impl.FormulaValidationHooks;
 import com.google.common.base.Charsets;
 
-@AllowedContext(section=SelectorSection.TEXT, displayOnly=true,isJavascript=false)
+@AllowedContext(section=SelectorSection.TEXT, isSql=false,displayOnly=true,isJavascript=false)
 public class FunctionUrlEncode extends EncodingFunctionBase {
     
     public FunctionUrlEncode() {

--- a/impl/src/test/goldfiles/FormulaFields/testRegex.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testRegex.xml
@@ -1,0 +1,171 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN COALESCE($!s0s!$.customtext__c,'') ~ CONCAT(CONCAT('^', $!s0s!$.customexpr__c), '$') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN COALESCE($!s0s!$.customtext__c,'') ~ CONCAT(CONCAT('^', $!s0s!$.customexpr__c), '$') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <JsOutput highPrec="true" nullAsNull="false">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="false">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>Error: ERROR: invalid regular expression: parentheses () not balanced</sql>
+         <javascript>Error: SyntaxError: Unterminated group</javascript>
+         <javascriptLp>Error: SyntaxError: Unterminated group</javascriptLp>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>Error: ERROR: invalid regular expression: parentheses () not balanced</sqlNullAsNull>
+         <javascriptNullAsNull>Error: SyntaxError: Unterminated group</javascriptNullAsNull>
+         <javascriptLpNullAsNull>Error: SyntaxError: Unterminated group</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/impl/src/test/java/com/force/formula/commands/FormulaCommandInvariantTest.java
+++ b/impl/src/test/java/com/force/formula/commands/FormulaCommandInvariantTest.java
@@ -1,0 +1,97 @@
+/**
+ * 
+ */
+package com.force.formula.commands;
+
+import java.util.List;
+
+import com.force.formula.FormulaCommand;
+import com.force.formula.FormulaCommandType;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.sql.SQLPair;
+
+import junit.framework.TestCase;
+
+/**
+ * Test that the standard formulas pass the invariants.  Currently tests only mutability,
+ * but can be extended to valiate allowedContext
+ *
+ * @author stamm
+ */
+public class FormulaCommandInvariantTest extends TestCase {
+    public FormulaCommandInvariantTest(String name) {
+        super(name);
+    }
+
+    public void testAllCommandInfosAreImmutable() {
+        // Iterate over all registered command infos and verify that they contain only final fields
+        StringBuilder results = new StringBuilder();
+        List<? extends FormulaCommandType> commandInfos = FormulaEngine.getFactory().getTypeRegistry().getCommands();
+        for (FormulaCommandType commandInfo : commandInfos) {
+            if ("REGEX".equals(commandInfo.getName())) {
+                continue;  // Ignore FunctionRegex because it has a mutable constant for testing
+            }
+            FormulaCommandInvariants.validateCommandImmutable(results, commandInfo);
+        }
+
+        assertTrue(results.toString(), results.length() == 0);
+
+        // Test the validation code itself
+        StringBuilder badResults = new StringBuilder();
+        FormulaCommandInvariants.validateCommandImmutable(badResults, new BadCommandInfo());
+        FormulaCommandInvariants.validateCommandImmutable(badResults, new ExtendedBadCommandInfo());
+        String className = getClass().getName();
+        assertEquals(
+            "BadCommandInfo(s) should not have passed validateCommandInfo()",
+            "CommandInfo[BadCommandInfo, "+className+"$BadCommandInfo] contains mutable field 'mutableField'\n"
+                + "CommandInfo[BadCommandInfo, "+className+"$BadCommandInfo] contains mutable field 'publicMutableField'\n"
+                + "CommandInfo[ExtendedBadCommandInfo, "+className+"$BadCommandInfo] contains mutable field 'mutableField'\n"
+                + "CommandInfo[ExtendedBadCommandInfo, "+className+"$BadCommandInfo] contains mutable field 'publicMutableField'\n",
+            badResults.toString());
+    }
+
+    static class BadCommandInfo extends FormulaCommandInfoImpl {
+        public BadCommandInfo() {
+            this("BadCommandInfo");
+        }
+
+        public BadCommandInfo(String name) {
+            super(name);
+            mutableField = "Mothra was here!";
+            publicMutableField = "Hey, she's been here too";
+        }
+
+        @Override
+        public FormulaCommand getCommand(FormulaAST node, FormulaContext context) throws FormulaException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public SQLPair getSQL(FormulaAST node, FormulaContext context, String[] args, String[] guards, TableAliasRegistry registry)
+            throws FormulaException {
+            throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
+            throw new UnsupportedOperationException();
+        }
+
+        String mutableField;
+        public String publicMutableField;
+        final String immutableField = "I am a good field";
+        public final String immutablePublicField = "I am also a good field (other than I am public which is crazy-bad coding)";
+    }
+
+    static class ExtendedBadCommandInfo extends BadCommandInfo {
+        public ExtendedBadCommandInfo() {
+            super("ExtendedBadCommandInfo");
+        }
+    }
+
+}

--- a/impl/src/test/java/com/force/formula/template/commands/FunctionRenameable.java
+++ b/impl/src/test/java/com/force/formula/template/commands/FunctionRenameable.java
@@ -30,7 +30,7 @@ import com.force.i18n.grammar.LanguageDictionary;
  * @since 0.2.0
  * @see FunctionFormat
  */
-@AllowedContext(section=SelectorSection.TEXT,displayOnly=true)
+@AllowedContext(section=SelectorSection.TEXT,isSql=false,displayOnly=true)
 public class FunctionRenameable extends FormulaCommandInfoImpl {
     public FunctionRenameable() {
         super("RENAMEABLE", Renameable.class, new Class[] { String.class });

--- a/impl/src/test/java/com/force/formula/template/commands/TemplateFunctionsTest.java
+++ b/impl/src/test/java/com/force/formula/template/commands/TemplateFunctionsTest.java
@@ -36,6 +36,7 @@ import com.force.formula.impl.FormulaValidationHooks;
 import com.force.formula.impl.FormulaValidationHooks.ParseOption;
 import com.force.formula.impl.InvalidFunctionReferenceException;
 import com.force.formula.impl.JvmMetrics;
+import com.force.formula.impl.RegexTooComplicatedException;
 import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.util.FormulaI18nUtils;
 import com.force.i18n.BaseLocalizer;
@@ -204,9 +205,29 @@ public class TemplateFunctionsTest extends ParserTestBase {
         } catch (PatternSyntaxException ex) {
             assertTrue(true);
         }
-
     }
     
+
+    /**
+     * Verify that REGEX() validations are bounded.
+     */
+    public void testBoundedRegex() throws Exception {
+        
+        int oldLimit = FunctionRegex.FORMULA_LIMIT;
+        try {
+            assertFalse(evaluateBoolean("REGEX(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaac\",\"(a*)+b\")"));
+            FunctionRegex.FORMULA_LIMIT = 100;  // Allow 100 characters
+            try {
+                evaluateBoolean("REGEX(\"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaac\",\"(a*)+b\")");
+                fail("Should fail with too complicated");
+            } catch (RegexTooComplicatedException ex) {
+                assert ex.getMessage().contains("(a*)+b");
+            }
+        } finally {
+            FunctionRegex.FORMULA_LIMIT = oldLimit;
+        }
+        
+    }
     
 
     

--- a/impl/src/test/resources/com/force/formula/impl/data/functionRegex
+++ b/impl/src/test/resources/com/force/formula/impl/data/functionRegex
@@ -1,0 +1,14 @@
+F.o,F\.o
+Foo,F\\.o
+Text,(a*)b
+Text,Text
+Text,ext
+Text,Te
+Text,^Text$
+Text,[T][e][x][t]
+Hello,((
+Hello,
+,(a*)?
+,a+
+aaaaaaaaaaaac,(a*)+b
+,

--- a/impl/src/test/resources/com/force/formula/impl/formulatests.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulatests.xml
@@ -13,7 +13,6 @@ author: Srikanth Yendluri/Doug Chasman
     <!--  Include math tests from the separate file -->
      <include href="formulatests-math.xml"/>
 
-
      <testcase name="testDateTimeValueWithInvalidString" devName="testDateTimeValueWithInvalidString"
          labelName="testDateTimeValueWithInvalidString" dataType="DateOnly" eval="formula,template"
          scale="2" precision="12"
@@ -2414,6 +2413,20 @@ author: Srikanth Yendluri/Doug Chasman
          <whyIgnoreSql db="spanner" numFailures="4">negative start greater than length works.</whyIgnoreSql>
          <whyIgnoreSql db="sqlite3" numFailures="2">negative start greater than length works.</whyIgnoreSql>
      </testcase>     
-     
+  
+     <testcase name="testRegex" devName="testRegex" labels="extended"
+         labelName="testRegex" dataType="Text"
+         dataFile="functionRegex" length="255"
+         whyIgnoreJs="negative start greater than length works in js"
+         code="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')">
+         <referencefield devName="customtext" labelName="customtext"
+                 dataType="Text" length="255"/>
+         <referencefield devName="customexpr" labelName="customexpr"
+                 dataType="Text" length="255"/>
+         <whyIgnoreSql db="mssql" unimplemented="true">Sqlserver doesn't allow regexp in SQL</whyIgnoreSql>
+         <whyIgnoreSql db="sqlite3" unimplemented="true">Not all sqlites support regexp</whyIgnoreSql>
+         <whyIgnoreSql db="oracle" numFailures="4">Oracle treats empty string like null, so regexp_like doesn't match ".*"</whyIgnoreSql>
+     </testcase>     
+
     
 </formula-test>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testRegex.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testRegex.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN REGEXP_LIKE(COALESCE($!s0s!$.customtext__c,''),CONCAT_WS(&quot;&quot;,CONCAT_WS(&quot;&quot;,'^', $!s0s!$.customexpr__c), '$')) THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN REGEXP_LIKE(COALESCE($!s0s!$.customtext__c,''),CONCAT_WS(&quot;&quot;,CONCAT_WS(&quot;&quot;,'^', $!s0s!$.customexpr__c), '$')) THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>Error: Mismatched parenthesis in regular expression.</sql>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>Error: Mismatched parenthesis in regular expression.</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testRegex.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testRegex.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN REGEXP_LIKE(NVL($!s0s!$.customtext__c,''),'^'||$!s0s!$.customexpr__c||'$') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN REGEXP_LIKE(NVL($!s0s!$.customtext__c,''),'^'||$!s0s!$.customexpr__c||'$') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>Error: ORA-12725: unmatched parentheses in regular expression </sql>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>Error: ORA-12725: unmatched parentheses in regular expression </sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/sqlite-test/src/test/goldfiles/FormulaFields/testRegex.xml
+++ b/sqlite-test/src/test/goldfiles/FormulaFields/testRegex.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c REGEXP COALESCE(COALESCE('^','')||COALESCE($!s0s!$.customexpr__c,''),'')||COALESCE('$','') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c REGEXP COALESCE(COALESCE('^','')||COALESCE($!s0s!$.customexpr__c,''),'')||COALESCE('$','') THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>Error: [SQLITE_ERROR] SQL error or missing database (no such function: REGEXP)</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testRegex.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testRegex.xml
@@ -1,0 +1,111 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testRegex">
+   <testInstance formula="if(REGEX(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN 1=0 THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN 1=0 THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[F.o, F\.o]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Foo, F\\.o]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, (a*)b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Text]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ext]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, Te]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, ^Text$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Text, [T][e][x][t]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ((]</inputvalues>
+         <formula>Error: java.util.regex.PatternSyntaxException</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>Error: java.util.regex.PatternSyntaxException</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hello, ]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, (a*)?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, a+]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[aaaaaaaaaaaac, (a*)+b]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[, ]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/test-utils/src/main/java/com/force/formula/commands/FormulaCommandInvariants.java
+++ b/test-utils/src/main/java/com/force/formula/commands/FormulaCommandInvariants.java
@@ -1,0 +1,33 @@
+package com.force.formula.commands;
+
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+
+import com.force.formula.FormulaCommandType;
+
+/**
+ * Validator of style of Formula Commands should be immutable
+ *
+ * @author stamm
+ * @since 0.3
+ *  */
+public class FormulaCommandInvariants {
+
+    public FormulaCommandInvariants() {
+        // TODO Auto-generated constructor stub
+    }
+
+    public static void validateCommandImmutable(StringBuilder results, FormulaCommandType commandInfo) {
+        Class<?> cls = commandInfo.getClass();
+        while (cls != null) {
+            for (Field field : cls.getDeclaredFields()) {
+                // Ignore this. It's not ideal but we made it modifiable for testing purposes.
+                if (!Modifier.isFinal(field.getModifiers())) {
+                    results.append("CommandInfo[").append(commandInfo.getName()).append(", ").append(cls.getName());
+                    results.append("] contains mutable field '").append(field.getName()).append("'\n");
+                }
+            }
+            cls = cls.getSuperclass();
+        }
+    }
+}


### PR DESCRIPTION
You may not want to support it in your DB for performance reasons, but it should be complete.
- Not supported in SqlServer, and the Oracle and Sqlite have issues with nulls. General changes
- Add isSql to AllowedContext and validate it when generating SQL to be clearer than "displayOnly" 
- Add in an invariant test to prevent mutable state on functions (except for Regexp)