### PR TITLE
Support a SQL Like() function

### DIFF
--- a/google-test/src/test/goldfiles/FormulaFields/Spanner/testLike.xml
+++ b/google-test/src/test/goldfiles/FormulaFields/Spanner/testLike.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
@@ -832,5 +832,13 @@ public interface FormulaSqlHooks extends FormulaSqlStyle {
         	return "RPAD(" + str + ", " + amount + ")";
         }
     }
-    
+
+    /**
+     * @return How to generate a "LIKE" comparison with an escape of a backslash character
+     * @param str the string to compare
+     * @param like the LIKE style string
+     */
+    default String sqlLike(String str, String like) {
+        return str + " LIKE " + like + " ESCAPE '\\'";
+    }
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
@@ -315,11 +315,6 @@ public interface FormulaGoogleHooks extends FormulaSqlHooks {
         return getSubstringFunction() + "(" + strArg + ", CASE WHEN " + startPosArg + " = 0 THEN 1 ELSE CAST(" + startPosArg  + " AS INT64) END, " + sqlEnsurePositive(sqlRoundScaleArg(lengthArg)) + ")";
     }
     
-	@Override
-    default Object sqlMakeStringComparable(Object str, boolean forCompare) {
-    	return str;
-    }
-    
     /**
      * Formulas are usually numeric, but some functions, like round or trunc, require a cast to ::int in postgres
      * @param argument scale argument
@@ -406,5 +401,9 @@ public interface FormulaGoogleHooks extends FormulaSqlHooks {
         return "REGEXP_CONTAINS(COALESCE(" + text + ",'')," + regexp + ")";
     }
 
+    @Override
+    default String sqlLike(String str, String like) {
+        return str + " LIKE " + like;
+    }
     
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaMySQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaMySQLHooks.java
@@ -434,6 +434,10 @@ public interface FormulaMySQLHooks extends FormulaSqlHooks {
 		return "binary " + str;
     }
 	
+	@Override
+    default String sqlLike(String str, String like) {
+        return str + " LIKE BINARY " + like;
+    }
 	
 	interface MariaDBHooks extends FormulaMySQLHooks {
 	    @Override

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaOracleHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaOracleHooks.java
@@ -378,5 +378,6 @@ public interface FormulaOracleHooks extends FormulaSqlHooks {
         }
         return sql.toString();
     }
-    
+
+	
 }

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaTransactSQLHooks.java
@@ -458,4 +458,9 @@ public interface FormulaTransactSQLHooks extends FormulaSqlHooks {
         return "1=0";
     }
 
+    @Override
+    default String sqlLike(String str, String like) {
+        // SQLServer supports character sets, so we have to escape '[' to match other SQL behavior
+        return sqlMakeStringComparable(str, true) + " LIKE REPLACE(" + like + ",'[','\\[') ESCAPE '\\'";
+    }
 }

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionLike.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionLike.java
@@ -1,0 +1,138 @@
+package com.force.formula.template.commands;
+
+import java.lang.reflect.Type;
+import java.util.Deque;
+import java.util.regex.Pattern;
+
+import com.force.formula.FormulaCommand;
+import com.force.formula.FormulaCommandType.AllowedContext;
+import com.force.formula.FormulaCommandType.SelectorSection;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.commands.AbstractFormulaCommand;
+import com.force.formula.commands.ConstantString;
+import com.force.formula.commands.FormulaCommandInfo;
+import com.force.formula.commands.FormulaCommandInfoImpl;
+import com.force.formula.commands.FormulaCommandValidator;
+import com.force.formula.commands.RuntimeType;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.IllegalArgumentTypeException;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.RegexTooComplicatedException;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
+import com.force.formula.parser.gen.FormulaTokenTypes;
+import com.force.formula.sql.SQLPair;
+import com.force.formula.template.commands.AccessCountedCharSequence.AccessCountExceededException;
+
+/** 
+ * LIKE(Text, LikeText)
+ * Returns TRUE if Text matches the SQL Like expression LikeText. Otherwise, it returns FALSE.
+ * Matches the entire string of Text, not just part, and should be case sensitive where possible.
+ */
+@AllowedContext(section=SelectorSection.TEXT)
+public class FunctionLike extends FormulaCommandInfoImpl implements FormulaCommandValidator {
+    public FunctionLike() {
+        super("LIKE");
+    }
+
+    @Override
+    public Class<?> validate(FormulaAST node, FormulaContext context, FormulaProperties properties)
+        throws FormulaException {
+        if (node.getNumberOfChildren() != 2) {
+            throw new WrongNumberOfArgumentsException(node.getText(), 2, node);
+        }
+
+        FormulaAST firstArg = (FormulaAST)node.getFirstChild();
+        FormulaAST secondArg = (FormulaAST)firstArg.getNextSibling();
+        Type firstType = firstArg.getDataType();
+        Type secondType = secondArg.getDataType();
+
+        if ( (!FormulaTypeUtils.isTypeText(firstType) && firstType != RuntimeType.class)
+                || (!FormulaTypeUtils.isTypeText(secondType) && secondType != RuntimeType.class)) {
+            throw new IllegalArgumentTypeException(node.getText());
+        }
+
+        if (firstType == RuntimeType.class || secondType == RuntimeType.class) {
+            return RuntimeType.class;
+        }
+
+        return Boolean.class;
+    }
+    
+    public static Pattern getPatternFromLike(String like) {
+        String converted = like.replaceAll("\\\\%", "\t")  // Get the escaped version
+                .replaceAll("\\\\_", "\f")
+                .replaceAll("([*?+^$(){}\\[])", "\\\\$1")  // Replace REGEX literals
+                .replaceAll("_", ".")  // Switch Percent/Underscore to regex 
+                .replaceAll("%", ".*")
+                .replaceAll("\f", "_")  // switch back to literals
+                .replaceAll("\t", "%");
+        return Pattern.compile(converted);
+    }
+
+    @Override
+    public FormulaCommand getCommand(FormulaAST node, FormulaContext context) throws FormulaException {
+        Pattern p = null;
+        FormulaAST regexNode = (FormulaAST)node.getFirstChild().getNextSibling();
+        if (regexNode.getType() == FormulaTokenTypes.STRING_LITERAL) {
+            p = getPatternFromLike(ConstantString.getStringValue(regexNode, true));
+        }
+        return new FunctionLikeCommand(this, p);
+    }
+
+    @Override
+    public SQLPair getSQL(FormulaAST node, FormulaContext context, String[] args, String[] guards, TableAliasRegistry registry)
+        throws FormulaException {
+        String sql = getSqlHooks(context).sqlLike(args[0], args[1]);
+        String guard = SQLPair.generateGuard(guards, null);
+        return new SQLPair(sql, guard);
+    }
+    
+    @Override
+    public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
+        // If the regexp is null, it should be empty string test (i.e. '^$').  
+        String likeStr = args[1].js;
+        likeStr = likeStr + ".replaceAll(/\\\\%/g,'\\t').replaceAll(/\\\\_/g,'\\f')"
+                + ".replaceAll(/([*?+^$(){}\\[])/g,'\\\\$1')"
+                + ".replaceAll(/_/g,'.').replaceAll(/%/g,'.*')"
+                + ".replaceAll(/\\f/g,'_').replaceAll(/\\t/g,'%')";
+        String regex = FormulaCommandInfoImpl.jsNvl2(args[1], "'^'+"+likeStr+"+'$'", "'^$'");
+        String js = "new RegExp("+regex+").test("+FormulaCommandInfoImpl.jsNvl(args[0].js, "''")+")";
+        return JsValue.generate(js, args, false);
+    }
+
+
+    static class FunctionLikeCommand extends AbstractFormulaCommand {
+        private static final long serialVersionUID = 1L;
+        private final Pattern constantPattern;
+
+        public FunctionLikeCommand(FormulaCommandInfo info, Pattern pattern) {
+            super(info);
+            this.constantPattern = pattern;
+        }
+
+        @Override
+        public void execute(FormulaRuntimeContext context, Deque<Object> stack) throws FormulaException {
+            Object regex = stack.pop();
+            Object input = stack.pop();
+            input = (input == null) ? "" : input;
+            regex = (regex == null) ? "" : regex;
+
+            try {
+                // use constant pattern if available
+                Pattern p = constantPattern;
+                if (p == null) {
+                    // otherwise compile
+                    p = getPatternFromLike(checkStringType(regex));
+                }
+                stack.push(p.matcher((new AccessCountedCharSequence(checkStringType(input), FunctionRegex.FORMULA_LIMIT))).matches());
+            } catch(AccessCountExceededException x) {
+                throw new RegexTooComplicatedException((String)regex); // NOPMD
+            }
+        }
+    }
+}

--- a/impl/src/test/goldfiles/FormulaFields/testLike.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testLike.xml
@@ -1,0 +1,237 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <JsOutput highPrec="true" nullAsNull="false">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c.replaceAll(/\\%/g,'\t').replaceAll(/\\_/g,'\f').replaceAll(/([*?+^$(){}\[])/g,'\\$1').replaceAll(/_/g,'.').replaceAll(/%/g,'.*').replaceAll(/\f/g,'_').replaceAll(/\t/g,'%')+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c.replaceAll(/\\%/g,'\t').replaceAll(/\\_/g,'\f').replaceAll(/([*?+^$(){}\[])/g,'\\$1').replaceAll(/_/g,'.').replaceAll(/%/g,'.*').replaceAll(/\f/g,'_').replaceAll(/\t/g,'%')+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="false">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c.replaceAll(/\\%/g,'\t').replaceAll(/\\_/g,'\f').replaceAll(/([*?+^$(){}\[])/g,'\\$1').replaceAll(/_/g,'.').replaceAll(/%/g,'.*').replaceAll(/\f/g,'_').replaceAll(/\t/g,'%')+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(new RegExp(($F.anl([context.record.customexpr__c])?'^$':'^'+context.record.customexpr__c.replaceAll(/\\%/g,'\t').replaceAll(/\\_/g,'\f').replaceAll(/([*?+^$(){}\[])/g,'\\$1').replaceAll(/_/g,'.').replaceAll(/%/g,'.*').replaceAll(/\f/g,'_').replaceAll(/\t/g,'%')+'$')).test($F.nvl(context.record.customtext__c,''))?&quot;TRUE&quot;:&quot;FALSE&quot;)</JsOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <javascript>FALSE</javascript>
+         <javascriptLp>FALSE</javascriptLp>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+         <javascriptNullAsNull>FALSE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>FALSE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <javascript>TRUE</javascript>
+         <javascriptLp>TRUE</javascriptLp>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+         <javascriptNullAsNull>TRUE</javascriptNullAsNull>
+         <javascriptLpNullAsNull>TRUE</javascriptLpNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/impl/src/test/java/com/force/formula/impl/BaseCustomizableParserTest.java
+++ b/impl/src/test/java/com/force/formula/impl/BaseCustomizableParserTest.java
@@ -59,6 +59,7 @@ import com.force.formula.commands.TrigCommandInfo;
 import com.force.formula.impl.BeanFormulaContext.BeanFormulaType;
 import com.force.formula.impl.sql.FormulaDefaultSqlStyle;
 import com.force.formula.template.commands.DynamicReference;
+import com.force.formula.template.commands.FunctionLike;
 import com.force.formula.template.commands.FunctionTemplate;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -184,6 +185,7 @@ public abstract class BaseCustomizableParserTest extends ParserTestBase {
         types.add(new FunctionInitCap());
         types.add(new FunctionChr());
         types.add(new FunctionAscii());
+        types.add(new FunctionLike());
         types.add(new BinaryMathCommandInfo("TRUNC", new FunctionTrunc()));
         types.add(new FunctionFormatDuration());
         types.add(new TrigCommandInfo(FormulaTrigFunction.SIN));

--- a/impl/src/test/resources/com/force/formula/impl/data/functionLike
+++ b/impl/src/test/resources/com/force/formula/impl/data/functionLike
@@ -1,0 +1,21 @@
+abcd,abc[def]
+Howdy,%dy
+Howdy,Ho_dy
+Howdy,ho%dy
+# Try unicode characters with case insensitivity.
+Cändy,CäNDY
+Cändy,CÄndy
+Cändy,C_NDY
+[,[
+],]
+a,[acdf]
+_n,[_n]
+%,%%
+Hi%Hi,Hi%%Hi
+\,\\
+%,\%
+H,\s
+H,*
+*,*
+?,?
+^$^$,^$^$

--- a/impl/src/test/resources/com/force/formula/impl/formulatests.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulatests.xml
@@ -2429,4 +2429,17 @@ author: Srikanth Yendluri/Doug Chasman
      </testcase>     
 
     
+     <testcase name="testLike" devName="testRegex" labels="extended"
+         labelName="testLike" dataType="Text"
+         dataFile="functionLike" length="255"
+         code="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')">
+         <referencefield devName="customtext" labelName="customtext"
+                 dataType="Text" length="255"/>
+         <referencefield devName="customexpr" labelName="customexpr"
+                 dataType="Text" length="255"/>
+         <whyIgnoreSql db="oracle" numFailures="2">Invalid escape character with \s, difficult to validate</whyIgnoreSql>
+         <whyIgnoreSql db="sqlite3" numFailures="6">Sqlite is case sensitive without a global pragma</whyIgnoreSql>
+     </testcase>     
+    
+    
 </formula-test>

--- a/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testLike.xml
+++ b/mysql-test/src/test/goldfiles/FormulaFields/MySQL/testLike.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE BINARY $!s0s!$.customexpr__c THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE BINARY $!s0s!$.customexpr__c THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/oracle-test/src/test/goldfiles/FormulaFields/testLike.xml
+++ b/oracle-test/src/test/goldfiles/FormulaFields/testLike.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>Error: ORA-01424: missing or illegal character following the escape character </sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>Error: ORA-01424: missing or illegal character following the escape character </sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/sqlite-test/src/test/goldfiles/FormulaFields/testLike.xml
+++ b/sqlite-test/src/test/goldfiles/FormulaFields/testLike.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c LIKE $!s0s!$.customexpr__c ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>

--- a/sqlserver-test/src/test/goldfiles/FormulaFields/testLike.xml
+++ b/sqlserver-test/src/test/goldfiles/FormulaFields/testLike.xml
@@ -1,0 +1,153 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<testCase name="testLike">
+   <testInstance formula="if(LIKE(customtext__c, customexpr__c),'TRUE','FALSE')" returntype="Text">
+    <SqlOutput nullAsNull="true">
+       <Sql>CASE WHEN $!s0s!$.customtext__c COLLATE Latin1_General_100_BIN2 LIKE REPLACE($!s0s!$.customexpr__c,'[','\[') ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+    <SqlOutput nullAsNull="false">
+       <Sql>CASE WHEN $!s0s!$.customtext__c COLLATE Latin1_General_100_BIN2 LIKE REPLACE($!s0s!$.customexpr__c,'[','\[') ESCAPE '\' THEN 'TRUE' ELSE 'FALSE' END</Sql>
+       <Guard>null</Guard>
+    </SqlOutput>
+      <result>
+      <inputvalues>[abcd, abc[def]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, %dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, Ho_dy]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Howdy, ho%dy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CäNDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, CÄndy]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Cändy, C_NDY]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[[, []</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[], ]]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[a, [acdf]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[_n, [_n]]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, %%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[Hi%Hi, Hi%%Hi]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[\, \\]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[%, \%]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, \s]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[H, *]</inputvalues>
+         <formula>FALSE</formula>
+         <sql>FALSE</sql>
+         <formulaNullAsNull>FALSE</formulaNullAsNull>
+         <sqlNullAsNull>FALSE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[*, *]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[?, ?]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+      <result>
+      <inputvalues>[^$^$, ^$^$]</inputvalues>
+         <formula>TRUE</formula>
+         <sql>TRUE</sql>
+         <formulaNullAsNull>TRUE</formulaNullAsNull>
+         <sqlNullAsNull>TRUE</sqlNullAsNull>
+      </result>
+   </testInstance>
+</testCase>


### PR DESCRIPTION
RegEx's had take unlimited time, so supporting them against the DB can be hazardous. `LIKE(String,String)` does a SQL LIKE supporting `%` and `_` in a case insensitive fashion in order
  to allow EndsWith functionality without doing unnatural and expensive things using REVERSE.
  Backslash `\` is used as the escape character
In javascript and java, it is converted to a regular expression. Oracle doesn't like invalid escape characters and Sqlite3 is case insensitive by default and can't
  be changed except globally, but works most other places.