### PR TITLE
Create formulaEngine.js and parameterize $F JS references

### DIFF
--- a/api/src/main/java/com/force/formula/FormulaContext.java
+++ b/api/src/main/java/com/force/formula/FormulaContext.java
@@ -215,6 +215,14 @@ public interface FormulaContext extends Tokenizer {
     default FormulaSqlStyle getSqlStyle() {
         return FormulaEngine.getHooks().getSqlStyle();
     }
+    
+    /**
+     * @return the javascript module to use for evaluating functions like "anl" and "noe" or "parseDateTime".
+     * Defaults to $F, but can be overridden to another global.
+     */
+    default String getJsEngMod() {
+        return "$F";
+    }
 
     
     /**

--- a/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
+++ b/api/src/main/java/com/force/formula/util/SingleValueFormulaContext.java
@@ -22,7 +22,7 @@ import com.force.formula.UnsupportedTypeException;
 /**
  * Class for implementing a Formula Context with a single value, normally called "Value."
  * This is intended to be used for writing validation formulas of a single value like 
- * <tt>Value > 0</tt> 
+ * <tt>Value &gt; 0</tt> 
  *
  * @author stamm
  * @since 0.2.6

--- a/impl/src/main/java/com/force/formula/commands/ConstantNumber.java
+++ b/impl/src/main/java/com/force/formula/commands/ConstantNumber.java
@@ -35,7 +35,7 @@ public class ConstantNumber extends ConstantBase {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return new JsValue("new $F.Decimal('" + node.getText() + "')", null, false);
+            return new JsValue("new " + context.getJsEngMod() + ".Decimal('" + node.getText() + "')", null, false);
         }
         return new JsValue(node.getText(), null, false);
     }

--- a/impl/src/main/java/com/force/formula/commands/FieldReferenceCommandInfo.java
+++ b/impl/src/main/java/com/force/formula/commands/FieldReferenceCommandInfo.java
@@ -398,14 +398,14 @@ public class FieldReferenceCommandInfo extends FormulaCommandInfoImpl implements
                 value = value + "/100.0";
             }
         } else if (datesAreStrings && dataType.isDateOnly()) {
-            value = FormulaCommandInfoImpl.jsNvl2(new JsValue(value, null, true),
+            value = FormulaCommandInfoImpl.jsNvl2(context, new JsValue(value, null, true),
                     String.format(FunctionDateValue.JS_FORMAT_TEMPLATE, value), "null");
         } else if (datesAreStrings && dataType.isTimeOnly()) {
-            value = FormulaCommandInfoImpl.jsNvl2(new JsValue(value, null, true),
+            value = FormulaCommandInfoImpl.jsNvl2(context, new JsValue(value, null, true),
                     String.format(FunctionTimeValue.JS_FORMAT_TEMPLATE, value), "null");
         } else if (datesAreStrings && dataType.isDateTime()) {
-            value = FormulaCommandInfoImpl.jsNvl2(new JsValue(value, null, true),
-                    "$F.parseDateTime(" + value + ")", "null");
+            value = FormulaCommandInfoImpl.jsNvl2(context, new JsValue(value, null, true),
+                    context.getJsEngMod() + ".parseDateTime(" + value + ")", "null");
         }
 
         return new JsValue(value,  guardJs, true);

--- a/impl/src/main/java/com/force/formula/commands/FormulaCommandInfoImpl.java
+++ b/impl/src/main/java/com/force/formula/commands/FormulaCommandInfoImpl.java
@@ -81,7 +81,7 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      *            the default value to return if test is null.
      * @return a javascript string that will return ifNull if value is null
      */
-    public static String jsNvl(String value, String ifNull) {
+    public static String jsNvl(FormulaContext context, String value, String ifNull) {
         // If we were given null, then return ifNull
         if (value == null || value.equalsIgnoreCase("null")) {
             // return "(ifNull)"
@@ -93,8 +93,8 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
             return new StringBuilder("(").append(value).append(")").toString();
         }
 
-        // return "$F.nvl(value, ifNull)"
-        return new StringBuilder("$F.nvl(").append(value).append(",").append(ifNull).append(")").toString();
+        // return context.getJsModule() + ".nvl(value, ifNull)"
+        return new StringBuilder(context.getJsEngMod() + ".nvl(").append(value).append(",").append(ifNull).append(")").toString();
     }
 
     /**
@@ -106,7 +106,7 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      *            the default value to return if test is (null or empty).
      * @return a javascript string that will return ifNull if value is null
      */
-    public static String jsNoe(String value, String ifNull) {
+    public static String jsNoe(FormulaContext context, String value, String ifNull) {
         // If we were given null, then return ifNull
         if (value == null || value.equalsIgnoreCase("null") || (value != null && FormulaTextUtil.isEmptyOrWhitespace(value))) {
             // return "(ifNull)"
@@ -118,8 +118,8 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
             return new StringBuilder("(").append(value).append(")").toString();
         }
 
-        // return "$F.nvl(value, ifNull)"
-        return new StringBuilder("$F.noe(").append(value).append(",").append(ifNull).append(")").toString();
+        // return context.getJsModule() + ".nvl(value, ifNull)"
+        return new StringBuilder(context.getJsEngMod() + ".noe(").append(value).append(",").append(ifNull).append(")").toString();
     }
 
     /**
@@ -133,8 +133,8 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      *            the default value to return
      * @return a javascript string that will return ifNull if test is null
      */
-    public static String jsNvl2(JsValue test, String value, String ifNull) {
-        return jsNvl2WithGuard(test, value, ifNull, false);
+    public static String jsNvl2(FormulaContext context, JsValue test, String value, String ifNull) {
+        return jsNvl2WithGuard(context, test, value, ifNull, false);
     }
 
     /**
@@ -150,7 +150,7 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      * @param withGuard should the guard be included in the test.
      * @return a javascript string that will return ifNull if test is null
      */
-    public static String jsNvl2WithGuard(JsValue test, String value, String ifNull, boolean withGuard) {
+    public static String jsNvl2WithGuard(FormulaContext context, JsValue test, String value, String ifNull, boolean withGuard) {
         // If we were given null, then return ifNull
         if (test == null || test.js.equalsIgnoreCase("null")) {
             // return "(ifNull)"
@@ -162,12 +162,12 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
             return new StringBuilder("(").append(value).append(")").toString();
         }
 
-        // return "($F.anl([test])?ifNull:value)"
+        // return "(" + context.getJsModule() + ".anl([test])?ifNull:value)"
         String guard = test.js;
         if (withGuard && test.guard != null) {
             guard = test.guard + "&&" + guard;
         }
-        return new StringBuilder("($F.anl([").append(guard).append("])?").append(ifNull).append(":").append(value)
+        return new StringBuilder("(" + context.getJsEngMod() + ".anl([").append(guard).append("])?").append(ifNull).append(":").append(value)
                 .append(")").toString();
     }
 
@@ -189,14 +189,14 @@ public abstract class FormulaCommandInfoImpl implements FormulaCommandInfo {
      * @return whether to use the "Decimal" or "Math" packages for math functions
      */
     protected static String jsMathPkg(FormulaContext context) {
-		return context.useHighPrecisionJs() ? "$F.Decimal" : "Math";
+		return context.useHighPrecisionJs() ? context.getJsEngMod() + ".Decimal" : "Math";
     }
 
     /**
      * Convert the value *to* a high precision decimal from a javascript number
      */
     protected static String jsToDec(FormulaContext context, String val) {
-        return context.useHighPrecisionJs() ? "(new $F.Decimal(" + val + "))" : val;
+        return context.useHighPrecisionJs() ? "(new " + context.getJsEngMod() + ".Decimal(" + val + "))" : val;
     }
 
     /**

--- a/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionAddMonths.java
@@ -75,7 +75,7 @@ public class FunctionAddMonths extends FormulaCommandInfoImpl implements Formula
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String js =  "$F.addmonths(" + args[0] + "," + jsToNum(context, args[1].js) + ")";
+        String js =  context.getJsEngMod() + ".addmonths(" + args[0] + "," + jsToNum(context, args[1].js) + ")";
         return JsValue.generate(js, args, true, args);
     }
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionBegins.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionBegins.java
@@ -3,10 +3,15 @@ package com.force.formula.commands;
 
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
@@ -35,7 +40,7 @@ public class FunctionBegins extends FormulaCommandInfoImpl {
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String js =  "!"+args[1]+"||"+args[0]+".lastIndexOf("+jsNvl(args[1].js,"''")+",0)===0";
+        String js =  "!"+args[1]+"||"+args[0]+".lastIndexOf("+jsNvl(context, args[1].js,"''")+",0)===0";
         return JsValue.forNonNullResult(js, args);
     }    
 }

--- a/impl/src/main/java/com/force/formula/commands/FunctionCase.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionCase.java
@@ -222,7 +222,7 @@ public class FunctionCase extends FormulaCommandInfoImpl implements FormulaComma
                     boolean hasEmpty = cases.contains("");
                     String arr = cases.stream().map(c->"'"+FormulaTextUtil.escapeForJavascriptString(c)+"'").collect(Collectors.joining(","));
                     // Match the null semantics of SQL here when matching picklists.
-                    js.append("[").append(arr).append("].indexOf(").append(!hasEmpty?args[0]:jsNvl(args[0].js, "\"\"")).append(")>=0?");
+                    js.append("[").append(arr).append("].indexOf(").append(!hasEmpty?args[0]:jsNvl(context, args[0].js, "\"\"")).append(")>=0?");
                     valueNode = (FormulaAST)whenNode.getNextSibling();
                     js.append("(").append(args[i+1].js).append("):");
                     couldBeNull |= args[i+1].couldBeNull;
@@ -238,7 +238,7 @@ public class FunctionCase extends FormulaCommandInfoImpl implements FormulaComma
                 //String condition;
                 whenNode = (FormulaAST)valueNode.getNextSibling();
                 // Make sure null != null by testings args[i]
-                js.append("("+args[i] + "&&("+OperatorEquality.wrapJsForEquality(args[0], expType)+"=="+OperatorEquality.wrapJsForEquality(args[i], expType)+"))?");
+                js.append("("+args[i] + "&&("+OperatorEquality.wrapJsForEquality(context, args[0], expType)+"=="+OperatorEquality.wrapJsForEquality(context, args[i], expType)+"))?");
                 valueNode = (FormulaAST)whenNode.getNextSibling();
                 js.append("(").append(args[i+1].js).append("):");
                 couldBeNull |= args[i+1].couldBeNull;

--- a/impl/src/main/java/com/force/formula/commands/FunctionContains.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionContains.java
@@ -3,10 +3,15 @@ package com.force.formula.commands;
 
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
@@ -37,7 +42,7 @@ public class FunctionContains extends FormulaCommandInfoImpl {
 
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String text = jsNvl(args[0].js, "''");  // Guard against text being null.  Note that FILTER above.
+        String text = jsNvl(context, args[0].js, "''");  // Guard against text being null.  Note that FILTER above.
         return JsValue.generate("(!"+args[1]+"||(("+text+").indexOf("+args[1]+")>=0))", args, false);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/FunctionDatetimeValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDatetimeValue.java
@@ -91,7 +91,7 @@ public class FunctionDatetimeValue extends FormulaCommandInfoImpl implements For
         } else if (inputDataType == BigDecimal.class) {
             return JsValue.forNonNullResult("new Date(" + jsToNum(context, args[0].js) + ")",args);
         } else {
-            return JsValue.forNonNullResult("$F.parseDateTime("+ args[0].js + ")", args);
+            return JsValue.forNonNullResult(context.getJsEngMod() + ".parseDateTime("+ args[0].js + ")", args);
         }
     }
    

--- a/impl/src/main/java/com/force/formula/commands/FunctionDay.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDay.java
@@ -44,7 +44,7 @@ public class FunctionDay extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("new $F.Decimal("+args[0].js+".getUTCDate())", args);
+            return JsValue.forNonNullResult("new " + context.getJsEngMod() + ".Decimal("+args[0].js+".getUTCDate())", args);
         }
         return JsValue.forNonNullResult(args[0].js+".getUTCDate()", args);
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionDayOfYear.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionDayOfYear.java
@@ -35,7 +35,7 @@ public class FunctionDayOfYear extends FormulaCommandInfoImpl {
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String js =  jsToDec(context, "$F.dayofyear(" + args[0] + ")");
+        String js =  jsToDec(context, context.getJsEngMod() + ".dayofyear(" + args[0] + ")");
         return JsValue.generate(js, args, true, args[0]);
     }
 

--- a/impl/src/main/java/com/force/formula/commands/FunctionFormatDuration.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionFormatDuration.java
@@ -144,15 +144,15 @@ public class FunctionFormatDuration extends FormulaCommandInfoImpl implements Fo
         Type lhsDataType = lhs.getDataType();
         if (lhsDataType == BigDecimal.class) {
             if (args.length == 1) {
-                return JsValue.forNonNullResult("$F.formatduration(Math.abs("+jsToNum(context,args[0].js)+"),false)", args);
+                return JsValue.forNonNullResult(context.getJsEngMod() + ".formatduration(Math.abs("+jsToNum(context,args[0].js)+"),false)", args);
             } else {
                 // Only guard against the value, not the isDays boolean.
-                return JsValue.forNonNullResult("$F.formatduration(Math.abs("+jsToNum(context,args[0].js)+"),"+args[1]+")", new JsValue[] {args[0]});
+                return JsValue.forNonNullResult(context.getJsEngMod() + ".formatduration(Math.abs("+jsToNum(context,args[0].js)+"),"+args[1]+")", new JsValue[] {args[0]});
             }
         } else if (lhsDataType == FormulaTime.class) {
-            return JsValue.forNonNullResult("$F.formatduration(Math.abs(("+args[1]+".getTime()-"+args[0]+".getTime())/1000),false)", args);
+            return JsValue.forNonNullResult(context.getJsEngMod() + ".formatduration(Math.abs(("+args[1]+".getTime()-"+args[0]+".getTime())/1000),false)", args);
         } else if (lhsDataType == FormulaDateTime.class) {
-            return JsValue.forNonNullResult("$F.formatduration(Math.abs(("+args[1]+".getTime()-"+args[0]+".getTime())/1000),true)", args);
+            return JsValue.forNonNullResult(context.getJsEngMod() + ".formatduration(Math.abs(("+args[1]+".getTime()-"+args[0]+".getTime())/1000),true)", args);
         } else {
             throw new UnsupportedOperationException();
         }    

--- a/impl/src/main/java/com/force/formula/commands/FunctionHour.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionHour.java
@@ -44,7 +44,7 @@ public class FunctionHour extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("new $F.Decimal("+args[0].js+".getUTCHours())", args);
+            return JsValue.forNonNullResult("new " + context.getJsEngMod() + ".Decimal("+args[0].js+".getUTCHours())", args);
         }
         return JsValue.forNonNullResult(jsToDec(context, args[0]+".getUTCHours()"), args);
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionIn.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIn.java
@@ -173,10 +173,10 @@ public class FunctionIn extends FormulaCommandInfoImpl implements FormulaCommand
             for (int i = 1; i < args.length; i++) {
                 // Decimal.js doesn't work right with Array includes...
                 if (type == BigDecimal.class && context.useHighPrecisionJs()) {
-                    js.append(jsNvl2(args[i], jsToNum(context, args[i].js),null)).append(",");
+                    js.append(jsNvl2(context, args[i], jsToNum(context, args[i].js),null)).append(",");
                 } else if (type == Date.class || type == FormulaDateTime.class) {
                     // Need to use getTime.
-                    js.append(jsNvl2(args[i], args[i].js + ".getTime()",null)).append(",");
+                    js.append(jsNvl2(context, args[i], args[i].js + ".getTime()",null)).append(",");
                 } else {
                     js.append(args[i]).append(",");
                 }
@@ -184,9 +184,9 @@ public class FunctionIn extends FormulaCommandInfoImpl implements FormulaCommand
             js.setLength(js.length()-1);
             Object value = args[0];
             if (type == BigDecimal.class && context.useHighPrecisionJs()) {
-                value = jsNvl2(args[0], jsToNum(context, args[0].js),null);
+                value = jsNvl2(context, args[0], jsToNum(context, args[0].js),null);
             } else if (type == Date.class || type == FormulaDateTime.class) {
-                value = jsNvl2(args[0], args[0].js + ".getTime()",null);
+                value = jsNvl2(context, args[0], args[0].js + ".getTime()",null);
             }           
             js.append("].filter(e=>e!=null).indexOf(").append(value).append(")>=0)");
         }

--- a/impl/src/main/java/com/force/formula/commands/FunctionInitCap.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionInitCap.java
@@ -35,7 +35,7 @@ public class FunctionInitCap extends FormulaCommandInfoImpl {
 
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        return JsValue.forNonNullResult("$F.initcap("+args[0] +")",args);
+        return JsValue.forNonNullResult(context.getJsEngMod() + ".initcap("+args[0] +")",args);
     }
     
     static class FunctionInitCapCommand extends AbstractFormulaCommand {

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsPickVal.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsPickVal.java
@@ -3,10 +3,24 @@ package com.force.formula.commands;
 import java.util.Deque;
 import java.util.List;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaFieldInfo;
+import com.force.formula.FormulaPicklistInfo;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.InvalidFieldReferenceException;
+import com.force.formula.UnsupportedTypeException;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 import com.force.i18n.commons.text.TextUtil;
@@ -128,16 +142,16 @@ public class FunctionIsPickVal extends FormulaCommandInfoImpl
         final FormulaAST lhs = (FormulaAST) node.getFirstChild();
         final FormulaAST rhs = (FormulaAST) lhs.getNextSibling();
 
-        final String lhsString = OperatorEquality.wrapJsForEquality(args[0], lhs.getDataType());
-        final String rhsString = OperatorEquality.wrapJsForEquality(args[1], rhs.getDataType());
+        final String lhsString = OperatorEquality.wrapJsForEquality(context, args[0], lhs.getDataType());
+        final String rhsString = OperatorEquality.wrapJsForEquality(context, args[1], rhs.getDataType());
 
         JsValue[] values = new JsValue[2];
-        values[0] = OperatorEquality.compareBulkJS(lhsString, lhs.getType(), rhsString, rhs.getType(), true, false,
+        values[0] = OperatorEquality.compareBulkJS(context, lhsString, lhs.getType(), rhsString, rhs.getType(), true, false,
                 false, args); // Equality comparison JsValue
         values[1] = JsValue.generate(args[0] + "==null", args, false); // Null value comparison
         if ("\"\"".equals(args[1].js) || "''".equals(args[1].js)) {
-            return JsValue.generate((jsNvl(values[0].buildJSWithGuard(), "false") + " || "
-                    + jsNvl(values[1].buildJSWithGuard(), "false")), null, false);
+            return JsValue.generate((jsNvl(context, values[0].buildJSWithGuard(), "false") + " || "
+                    + jsNvl(context, values[1].buildJSWithGuard(), "false")), null, false);
         }
         return values[0];
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsoWeek.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsoWeek.java
@@ -48,7 +48,7 @@ public class FunctionIsoWeek extends FormulaCommandInfoImpl implements FormulaCo
   
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String js =  jsToDec(context, "$F.isoweek(" + args[0] + ")");
+        String js =  jsToDec(context, context.getJsEngMod() + ".isoweek(" + args[0] + ")");
         return JsValue.generate(js, args, true, args[0]);
     }
     

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsoYear.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsoYear.java
@@ -49,7 +49,7 @@ public class FunctionIsoYear extends FormulaCommandInfoImpl implements FormulaCo
   
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        String js =  jsToDec(context, "$F.isoyear(" + args[0] + ")");
+        String js =  jsToDec(context, context.getJsEngMod() + ".isoyear(" + args[0] + ")");
         return JsValue.generate(js, args, true, args[0]);
     }
     

--- a/impl/src/main/java/com/force/formula/commands/FunctionJsonPathValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionJsonPathValue.java
@@ -128,8 +128,8 @@ public class FunctionJsonPathValue extends FormulaCommandInfoImpl implements For
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        //return JsValue.forNonNullResult("typeof $F==='undefined'?undefined:($F.jsonPath("+args[0]+",((!"+args[1]+"||'').startsWith('$')?'$.':'')+"+args[1]+")||'')", args);
-        return JsValue.forNonNullResult("typeof $F==='undefined'?undefined:(String($F.jsonPath(JSON.parse("+args[0]+"),"+args[1]+")||''))", args);
+        //return JsValue.forNonNullResult("typeof $F==='undefined'?undefined:(" + context.getJsModule() + ".jsonPath("+args[0]+",((!"+args[1]+"||'').startsWith('$')?'$.':'')+"+args[1]+")||'')", args);
+        return JsValue.forNonNullResult("typeof "+context.getJsEngMod()+"==='undefined'?undefined:(String(" + context.getJsEngMod() + ".jsonPath(JSON.parse("+args[0]+"),"+args[1]+")||''))", args);
     }
 
     static class FunctionJsonValueCommand extends AbstractFormulaCommand {

--- a/impl/src/main/java/com/force/formula/commands/FunctionJsonValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionJsonValue.java
@@ -127,7 +127,7 @@ public class FunctionJsonValue extends FormulaCommandInfoImpl implements Formula
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        return JsValue.generate("$F.tostr(JSON.parse("+args[0]+"||'{}')["+args[1]+"])", args, true);
+        return JsValue.generate(context.getJsEngMod() + ".tostr(JSON.parse("+args[0]+"||'{}')["+args[1]+"])", args, true);
     }
 
     static class FunctionJsonValueCommand extends AbstractFormulaCommand {

--- a/impl/src/main/java/com/force/formula/commands/FunctionLen.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLen.java
@@ -3,10 +3,16 @@ package com.force.formula.commands;
 import java.math.BigDecimal;
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
@@ -40,7 +46,7 @@ public class FunctionLen extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         // Yeah, this is absurd, but whaddayagonna do.  Swallow the guard and always return 0
-        String js = jsToDec(context, jsNvl2WithGuard(args[0], "("+args[0]+").length", jsToDec(context,"0"), true));  // Yeah, zero.  Weird.
+        String js = jsToDec(context, jsNvl2WithGuard(context, args[0], "("+args[0]+").length", jsToDec(context,"0"), true));  // Yeah, zero.  Weird.
         return new JsValue(js, null, false);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/FunctionLower.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLower.java
@@ -4,10 +4,20 @@ import java.lang.reflect.Type;
 import java.util.Deque;
 import java.util.Locale;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.FormulaValidationHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.sql.SQLPair;
 import com.force.i18n.LocaleUtils;
 
@@ -76,7 +86,7 @@ public class FunctionLower extends FormulaCommandInfoImpl implements FormulaComm
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (node.getNumberOfChildren() == 2) {
             // Ignore guards[1] in js
-            return JsValue.generate(args[0] + ".toLocaleLowerCase("+FunctionUpper.getLanguageTag(args[1])+")", args, false, args[0]);
+            return JsValue.generate(args[0] + ".toLocaleLowerCase("+FunctionUpper.getLanguageTag(context, args[1])+")", args, false, args[0]);
         } else {
             return JsValue.forNonNullResult(args[0] + ".toLowerCase()", args); 
         }

--- a/impl/src/main/java/com/force/formula/commands/FunctionLpad.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionLpad.java
@@ -3,10 +3,16 @@ package com.force.formula.commands;
 import java.math.BigDecimal;
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
@@ -52,9 +58,9 @@ public class FunctionLpad extends FormulaCommandInfoImpl {
         // Per SQL convention, LPAD should return null if
         // 1) the original value is null
         // 2) the end length is null or < 1
-        String padValue = (node.getNumberOfChildren() == 3) ? jsNvl(args[2].js, "' '") : "' '";
+        String padValue = (node.getNumberOfChildren() == 3) ? jsNvl(context, args[2].js, "' '") : "' '";
         // The pad value can be null, we guard against it above
-        return JsValue.generate("$F.lpad("+args[0]+","+jsToNum(context, args[1].js)+","+padValue+")", args, args[0].couldBeNull || args[1].couldBeNull, args[0], args[1]);
+        return JsValue.generate(context.getJsEngMod() + ".lpad("+args[0]+","+jsToNum(context, args[1].js)+","+padValue+")", args, args[0].couldBeNull || args[1].couldBeNull, args[0], args[1]);
         // NOTE: This is incorrect.  It needs to check for the length being < args[1] and if so return a substring
         //return "(!("+args[0]+")||!("+args[1]+")||"+args[1]+"<1)?null:"+args[1]+"<"+(Array("+MAXPAD+").join("+padValue+")+"+args[0]+").slice(-"+args[1]+")";
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionMinute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMinute.java
@@ -44,7 +44,7 @@ public class FunctionMinute extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("new $F.Decimal("+args[0].js+".getUTCMinutes())", args);
+            return JsValue.forNonNullResult("new " + context.getJsEngMod() + ".Decimal("+args[0].js+".getUTCMinutes())", args);
         }
         return JsValue.forNonNullResult(jsToDec(context, args[0]+".getUTCMinutes()"), args);
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionMonth.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionMonth.java
@@ -44,7 +44,7 @@ public class FunctionMonth extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("new $F.Decimal("+args[0].js+".getUTCMonth()+1)", args);
+            return JsValue.forNonNullResult("new " + context.getJsEngMod() + ".Decimal("+args[0].js+".getUTCMonth()+1)", args);
         }
         return JsValue.forNonNullResult(jsToDec(context, args[0]+".getUTCMonth()+1"),args);
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionNullValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionNullValue.java
@@ -4,10 +4,23 @@ package com.force.formula.commands;
 import java.lang.reflect.Type;
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaEngine;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaGeolocation;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.IllegalArgumentTypeException;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -87,7 +100,7 @@ public class FunctionNullValue extends FormulaCommandInfoImpl implements Formula
         // Get guard from arg[0] and put in inside the value.  Same with the alternative.
         String value = args[0].guard != null ? "(" + args[0].guard + ")?(" + args[0].js + "):null": args[0].js;
         String alternate = args[1].guard != null ? "(" + args[1].guard + ")?(" + args[1].js + "):null": args[1].js;
-        return JsValue.generate(jsNvl(value, alternate), new JsValue[0], args[1].couldBeNull && args[0].couldBeNull);  // Can be null only if both could be
+        return JsValue.generate(jsNvl(context, value, alternate), new JsValue[0], args[1].couldBeNull && args[0].couldBeNull);  // Can be null only if both could be
     }
 
     protected boolean localTreatAsString(FormulaContext context, FormulaAST node) {

--- a/impl/src/main/java/com/force/formula/commands/FunctionOr.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionOr.java
@@ -4,10 +4,16 @@ import java.util.Arrays;
 import java.util.Deque;
 import java.util.stream.Collectors;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.Thunk;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -126,7 +132,7 @@ public class FunctionOr extends FormulaCommandInfoImpl implements FormulaCommand
 
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        return new JsValue(jsNvl(Arrays.asList(args).stream().map((a) -> a.buildJSWithGuard())
+        return new JsValue(jsNvl(context, Arrays.asList(args).stream().map((a) -> a.buildJSWithGuard())
                 .collect(Collectors.joining(")||(", "(", ")")), "false"), null, false);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/FunctionPi.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionPi.java
@@ -45,8 +45,8 @@ public class FunctionPi extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            // $F.Decimal.PI doesn't work right, but acos does.
-            return JsValue.forNonNullResult("$F.Decimal.acos(-1)",null);
+            // " + context.getJsModule() + ".Decimal.PI doesn't work right, but acos does.
+            return JsValue.forNonNullResult(context.getJsEngMod() + ".Decimal.acos(-1)",null);
         } else {
             return JsValue.forNonNullResult("Math.PI",null);
         }

--- a/impl/src/main/java/com/force/formula/commands/FunctionUpper.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionUpper.java
@@ -4,10 +4,20 @@ import java.lang.reflect.Type;
 import java.util.Deque;
 import java.util.Locale;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.FormulaValidationHooks;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.sql.SQLPair;
 import com.force.i18n.LocaleUtils;
 
@@ -72,14 +82,14 @@ public class FunctionUpper extends FormulaCommandInfoImpl implements FormulaComm
         return resultType;
     }
     
-    static String getLanguageTag(JsValue arg) {
-        return jsNvl2(arg,arg.js+".replace(\"_\",\"-\")","'en'");
+    static String getLanguageTag(FormulaContext context, JsValue arg) {
+        return jsNvl2(context, arg,arg.js+".replace(\"_\",\"-\")","'en'");
     }
 
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (node.getNumberOfChildren() == 2) {
-            return JsValue.generate(args[0] + ".toLocaleUpperCase("+getLanguageTag(args[1])+")", args, false, args[0]);    
+            return JsValue.generate(args[0] + ".toLocaleUpperCase("+getLanguageTag(context, args[1])+")", args, false, args[0]);    
         } else {
             return JsValue.forNonNullResult(args[0] + ".toUpperCase()", args); 
         }

--- a/impl/src/main/java/com/force/formula/commands/FunctionValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionValue.java
@@ -37,7 +37,7 @@ public class FunctionValue extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("$F.Decimal(" + args[0] + ")", args);
+            return JsValue.forNonNullResult(context.getJsEngMod() + ".Decimal(" + args[0] + ")", args);
         }
         return JsValue.forNonNullResult("Number(" + args[0] + ")", args);
     }

--- a/impl/src/main/java/com/force/formula/commands/FunctionYear.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionYear.java
@@ -44,7 +44,7 @@ public class FunctionYear extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         if (context.useHighPrecisionJs()) {
-            return JsValue.forNonNullResult("new $F.Decimal("+args[0].js+".getUTCFullYear())", args);
+            return JsValue.forNonNullResult("new " + context.getJsEngMod() + ".Decimal("+args[0].js+".getUTCFullYear())", args);
         }
         return JsValue.forNonNullResult(args[0]+".getUTCFullYear()", args);
     }

--- a/impl/src/main/java/com/force/formula/commands/OperatorAddOrSubtract.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorAddOrSubtract.java
@@ -299,7 +299,7 @@ public class OperatorAddOrSubtract extends FormulaCommandInfoImpl implements For
             if (rhs == FormulaDateTime.class) {
                 // Get the diff between the dates
                 if (context.useHighPrecisionJs()) {
-                    js = "new $F.Decimal((" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000)";
+                    js = "new " + context.getJsEngMod() + ".Decimal((" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000)";
                 } else {
                     js = "(" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000";
                 }
@@ -309,7 +309,7 @@ public class OperatorAddOrSubtract extends FormulaCommandInfoImpl implements For
         } else if (lhs == Date.class) {
             if (rhs == Date.class) {
                 if (context.useHighPrecisionJs()) {
-                    js = "new $F.Decimal((" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000)";
+                    js = "new " + context.getJsEngMod() + ".Decimal((" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000)";
                 } else {
                     js = "(" + args[0] + ".getTime()" + operator + args[1] + ".getTime())/86400000";
                 }
@@ -325,7 +325,7 @@ public class OperatorAddOrSubtract extends FormulaCommandInfoImpl implements For
             if (rhs == FormulaTime.class) {
                 // Negative mod issues, so add Millis before mod-ing
                 if (context.useHighPrecisionJs()) {
-                    js = "(new $F.Decimal(" + args[0] + ".getTime()" + operator + args[1]+".getTime()+"+FormulaDateUtil.MILLISECONDSPERDAY+").mod("+FormulaDateUtil.MILLISECONDSPERDAY+"))";
+                    js = "(new " + context.getJsEngMod() + ".Decimal(" + args[0] + ".getTime()" + operator + args[1]+".getTime()+"+FormulaDateUtil.MILLISECONDSPERDAY+").mod("+FormulaDateUtil.MILLISECONDSPERDAY+"))";
                 } else {
                     js = "((" + args[0] + ".getTime()" + operator + args[1]+".getTime()+"+FormulaDateUtil.MILLISECONDSPERDAY+")%"+FormulaDateUtil.MILLISECONDSPERDAY+")";
                 }
@@ -336,7 +336,7 @@ public class OperatorAddOrSubtract extends FormulaCommandInfoImpl implements For
             js = "new Date(" + args[1] + ".getTime()" + operator + jsToNum(context, args[0].js)+")"  ;          
         } else if (lhs == String.class && rhs == String.class) {
             // TODO: see FunctionConcat
-            return JsValue.generate("(" + FormulaCommandInfoImpl.jsNvl(args[0].js, "''") + operator + FormulaCommandInfoImpl.jsNvl(args[1].js, "''") + ")", args, false);
+            return JsValue.generate("(" + FormulaCommandInfoImpl.jsNvl(context, args[0].js, "''") + operator + FormulaCommandInfoImpl.jsNvl(context, args[1].js, "''") + ")", args, false);
         } else if (lhs == BigDecimal.class && context.useHighPrecisionJs()) {
             js = args[0] + (performAddition ? ".add(" : ".sub(" ) + args[1] + ")";
         } else {

--- a/impl/src/main/java/com/force/formula/commands/OperatorConcat.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorConcat.java
@@ -3,10 +3,15 @@ package com.force.formula.commands;
 
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
 import com.force.formula.sql.SQLPair;
 
 /**
@@ -36,7 +41,7 @@ public class OperatorConcat extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         // TODO, nulls turn into "".  Maybe very wrong.
-        return JsValue.generate(jsNvl(args[0].js,"''") + "+" + jsNvl(args[1].js,"''"), args, false);
+        return JsValue.generate(jsNvl(context, args[0].js,"''") + "+" + jsNvl(context, args[1].js,"''"), args, false);
     }
 
 

--- a/impl/src/main/java/com/force/formula/commands/OperatorEquality.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorEquality.java
@@ -5,10 +5,25 @@ import java.math.BigDecimal;
 import java.util.Date;
 import java.util.Deque;
 
-import com.force.formula.*;
+import com.force.formula.FieldSetMemberInfo;
+import com.force.formula.FormulaCommand;
 import com.force.formula.FormulaCommandType.AllowedContext;
 import com.force.formula.FormulaCommandType.SelectorSection;
-import com.force.formula.impl.*;
+import com.force.formula.FormulaContext;
+import com.force.formula.FormulaDataType;
+import com.force.formula.FormulaDateTime;
+import com.force.formula.FormulaException;
+import com.force.formula.FormulaGeolocation;
+import com.force.formula.FormulaProperties;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.impl.FormulaAST;
+import com.force.formula.impl.FormulaSqlHooks;
+import com.force.formula.impl.FormulaTypeUtils;
+import com.force.formula.impl.IllegalArgumentTypeException;
+import com.force.formula.impl.JsValue;
+import com.force.formula.impl.TableAliasRegistry;
+import com.force.formula.impl.WrongArgumentTypeException;
+import com.force.formula.impl.WrongNumberOfArgumentsException;
 import com.force.formula.parser.gen.FormulaTokenTypes;
 import com.force.formula.sql.SQLPair;
 
@@ -115,17 +130,17 @@ public class OperatorEquality extends FormulaCommandInfoImpl implements FormulaC
      * @param argType the argument type
      * @return a javascript value suitable for testing equality
      */
-    public static String wrapJsForEquality(JsValue arg, Type argType) {
+    public static String wrapJsForEquality(FormulaContext context, JsValue arg, Type argType) {
         // convert date to number for comparison so it doesn't try and compare date objects
         if (argType == Date.class || argType == FormulaDateTime.class) {
             if (arg.couldBeNull) {
-                return jsNvl2(arg, arg.js+".getTime()", "null");
+                return jsNvl2(context, arg, arg.js+".getTime()", "null");
             } else {
                 return arg.js + ".getTime()";
             }
         }
         if (argType == String.class && arg.couldBeNull) {
-            return jsNvl2WithGuard(arg, arg.js, "null", true);
+            return jsNvl2WithGuard(context, arg, arg.js, "null", true);
         } else {
             return arg.js;
         }
@@ -256,20 +271,20 @@ public class OperatorEquality extends FormulaCommandInfoImpl implements FormulaC
      * @param guards the guards to use for the comparison which will be included in the JSValue
      * @return a == or != comparison of the values
      */
-    public static JsValue compareBulkJS(String lhs, int lhsType, String rhs, int rhsType, boolean treatAsString,
+    public static JsValue compareBulkJS(FormulaContext context, String lhs, int lhsType, String rhs, int rhsType, boolean treatAsString,
             boolean negate, boolean highPrec, JsValue... guards) {
 
         if (treatAsString) {
             String saveRhs = rhs;
             if (rhsType != FormulaTokenTypes.STRING_LITERAL)
-                rhs = jsNoe(rhs, jsNvl(lhs, "''") + "+'x'");
+                rhs = jsNoe(context, rhs, jsNvl(context, lhs, "''") + "+'x'");
             else if ("''".equals(rhs) || "\"\"".equals(rhs))
-            	rhs = jsNvl(lhs, "''") + "+'x'";
+            	rhs = jsNvl(context, lhs, "''") + "+'x'";
             
             if (lhsType != FormulaTokenTypes.STRING_LITERAL)
-                lhs = jsNoe(lhs, jsNvl(saveRhs, "''") + "+'x'");
+                lhs = jsNoe(context, lhs, jsNvl(context, saveRhs, "''") + "+'x'");
             else if ("''".equals(lhs) || "\"\"".equals(lhs))
-                lhs = jsNvl(saveRhs, "''") + "+'x'";
+                lhs = jsNvl(context, saveRhs, "''") + "+'x'";
         }
         
         if (highPrec) {
@@ -294,13 +309,13 @@ public class OperatorEquality extends FormulaCommandInfoImpl implements FormulaC
         final FormulaAST lhs = (FormulaAST)node.getFirstChild();
         final FormulaAST rhs = (FormulaAST)lhs.getNextSibling();
         
-        final String lhsString = wrapJsForEquality(args[0], lhs.getDataType());
-        final String rhsString = wrapJsForEquality(args[1], rhs.getDataType());
+        final String lhsString = wrapJsForEquality(context, args[0], lhs.getDataType());
+        final String rhsString = wrapJsForEquality(context, args[1], rhs.getDataType());
         
         // See note above...
         final boolean highPres = lhs.getDataType() == BigDecimal.class && context.useHighPrecisionJs();
         
-        return compareBulkJS(lhsString, lhs.getType(), rhsString, rhs.getType(), treatAsString(node),
+        return compareBulkJS(context, lhsString, lhs.getType(), rhsString, rhs.getType(), treatAsString(node),
                 "<>".equals(getName()), highPres, args);
     }
 }

--- a/impl/src/main/java/com/force/formula/commands/OperatorPower.java
+++ b/impl/src/main/java/com/force/formula/commands/OperatorPower.java
@@ -49,10 +49,10 @@ public class OperatorPower extends BinaryMathCommandBehavior {
             
             // Doing the guard was difficult as well
             //String guard = "(Math.log(Math.abs("+args[0]+"))*"+args[1]+"<39)";
-            //return JsValue.generate("("+guard+"?Decimal.pow("+ args[0] + "," + args[1] + ") : new $F.Decimal(0))", args, false, args);
+            //return JsValue.generate("("+guard+"?Decimal.pow("+ args[0] + "," + args[1] + ") : new " + context.getJsModule() + ".Decimal(0))", args, false, args);
             
             // This reduces the precision of Pow, but is safe and matches java
-            return JsValue.generate("new $F.Decimal(Math.pow("+args[0] + "," + args[1]+ "))", args, false, args);
+            return JsValue.generate("new " + context.getJsEngMod() + ".Decimal(Math.pow("+args[0] + "," + args[1]+ "))", args, false, args);
         }
         return JsValue.generate("Math.pow("+args[0] + "," + args[1]+ ")", args, false, args);
     }

--- a/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaSqlHooks.java
@@ -567,7 +567,7 @@ public interface FormulaSqlHooks extends FormulaSqlStyle {
      * and lengthArgs treated as positive
      * @param strArg the value of the string to substring
      * @param startPosArg the number of the start position
-     * @param length the number of characters to return, with negative numbers treated as zero
+     * @param lengthArg the number of characters to return, with negative numbers treated as zero
      */
     default String sqlSubstrWithNegStart(String strArg, String startPosArg, String lengthArg) {
         return getSubstringFunction() + "(" + strArg + ", " + sqlRoundScaleArg(startPosArg) + ", " + sqlEnsurePositive(sqlRoundScaleArg(lengthArg)) + ")";

--- a/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
@@ -651,7 +651,7 @@ public interface FormulaValidationHooks extends FormulaEngineHooks {
     
     
     /**
-     * @return whether java & javascript should treat null months in ADDMONTHS() as zero, 
+     * @return whether java and javascript should treat null months in ADDMONTHS() as zero, 
      * and return the passed in date if true.  Defaults to false, which returns null.
      */
     default boolean functionHook_addNullMonthsAsZero() {

--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaGoogleHooks.java
@@ -141,7 +141,7 @@ public interface FormulaGoogleHooks extends FormulaSqlHooks {
     }
     
     /**
-     * @see specification in FunctionAddMonths.java
+     * see specification in FunctionAddMonths.java
      * @return the format to use for adding months.
      * 
      * This is made rather difficult because interval month isn't supported for DateTimes in spanner.

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionLike.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionLike.java
@@ -100,8 +100,8 @@ public class FunctionLike extends FormulaCommandInfoImpl implements FormulaComma
                 + ".replaceAll(/([*?+^$(){}\\[])/g,'\\\\$1')"
                 + ".replaceAll(/_/g,'.').replaceAll(/%/g,'.*')"
                 + ".replaceAll(/\\f/g,'_').replaceAll(/\\t/g,'%')";
-        String regex = FormulaCommandInfoImpl.jsNvl2(args[1], "'^'+"+likeStr+"+'$'", "'^$'");
-        String js = "new RegExp("+regex+").test("+FormulaCommandInfoImpl.jsNvl(args[0].js, "''")+")";
+        String regex = FormulaCommandInfoImpl.jsNvl2(context, args[1], "'^'+"+likeStr+"+'$'", "'^$'");
+        String js = "new RegExp("+regex+").test("+FormulaCommandInfoImpl.jsNvl(context, args[0].js, "''")+")";
         return JsValue.generate(js, args, false);
     }
 

--- a/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
+++ b/impl/src/main/java/com/force/formula/template/commands/FunctionRegex.java
@@ -92,7 +92,7 @@ public class FunctionRegex extends FormulaCommandInfoImpl implements FormulaComm
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         // If the regexp is null, it should be empty string test (i.e. '^$').  
-        String js = "new RegExp("+FormulaCommandInfoImpl.jsNvl2(args[1], "'^'+"+args[1].js+"+'$'", "'^$'")+").test("+FormulaCommandInfoImpl.jsNvl(args[0].js, "''")+")";
+        String js = "new RegExp("+FormulaCommandInfoImpl.jsNvl2(context, args[1], "'^'+"+args[1].js+"+'$'", "'^$'")+").test("+FormulaCommandInfoImpl.jsNvl(context, args[0].js, "''")+")";
         return JsValue.generate(js, args, false);
     }
 

--- a/impl/src/main/resources/com/force/formula/formulaEngine.js
+++ b/impl/src/main/resources/com/force/formula/formulaEngine.js
@@ -1,0 +1,173 @@
+/**
+ * Copyright (C) 2019-2022 salesforce.com, inc.
+ * Formula Engine Client Side Library
+ * This is a non "module" version to provide standard implementations.
+ */
+ 
+ var FormulaEngine = {};
+/*
+ * Utility functions for the Client Formula Engine
+ * Equivalent to Oracle's NVL function.
+ * @param {Object} value - the value to check
+ * @param {Object} ifNull - returned if value is null or undefined
+ * @returns {Object} value if value is not null or undefined, otherwise ifNull
+ */
+FormulaEngine.nvl = function(value, ifNull) {
+    return value !== null && value !== undefined ? value : ifNull;
+}
+/*
+ * Utility functions for the Client Formula Engine - Equivalent of AuraUtil.js
+ * Null Or Empty - Return value if value is not null and not an empty string, ifNull otherwise.
+ * @param {Object} value - the value to check
+ * @param {Object} ifNull - returned if value is null or undefined or empty
+ * @returns {Object} value if value is not null or undefined, otherwise ifNull
+ */
+FormulaEngine.noe = function(value, ifNull) {
+    if (value === undefined || value === null || value === '') {
+        return ifNull;
+    }
+    return value;
+}
+/**
+ * Checks all tests and returns true if any are null or undefined.
+ * @param {List} tests - the list of values to check
+ * @returns {boolean} true if any value in tests is null or undefined
+ */
+FormulaEngine.anl = function(tests) {
+    return Array.isArray(tests) && tests.some(val => val === null || val === undefined);
+}
+
+/**
+ * Return the value as a string, while leaving null and undefined alone.
+ * @param {Object} value - the object to stringify
+ * @returns {String} a stringified version of value
+ */
+FormulaEngine.tostr = function(value) {
+    if(value===undefined||value===null||value==='') {
+        return value;
+    }        
+    return String(value)
+}
+
+/**
+ * Chrome, Node & GraalJS have lenient date parsing for 'YYYY-MM-DD HH:MM:SS'.  Others require ecmascript ISO formatting only (with T & Z).
+ * try both
+ * @param {String} value - a string value that is similar to an ISO date format.
+ * @returns {Date} - a date object that may be invalid
+ */
+FormulaEngine.parseDateTime = function(value) {
+    if (value===undefined||value===null||value==='') {
+        return null;
+    }
+    var d = new Date(value.trim().replace(' ','T')+'Z'); 
+    return isNaN(d) ? new Date(value.trim() + ' GMT') : d;
+}
+
+/**
+ * ADDMONTHS()
+ * Note, Javascript setMonths has strange behavior since it'll make January 30th + 1 month may be March.  
+ * And last day needs to remain last day to match oracle.
+ * So if it's the last day of the month, we add one to the day and add the month, then remove the day.  
+ * Otherwise we use the "set Date to 0 to be last day of previous month" javascript behavior 
+ * so Jan 30 + 1 month will be Feb 28 in a non-leap year 
+ * @param {Date} d - a date to add months to
+ * @param {Number} months - the number of months to add to the date
+ * @returns {Date} - the date with the numver of months added
+ */
+FormulaEngine.addmonths = function(d,months) {
+    if (d==null||d==null) return null;
+    if (!months) return d;
+    var lastDay=d.getUTCDay()==(new Date(Date.UTC(d.getUTCFullYear(),d.getUTCMonth()+1,0))).getUTCDay();
+    var adj=new Date(d.getTime()+(lastDay?86400000:0));
+    adj.setUTCMonth(adj.getUTCMonth()+Math.trunc(months));
+    if (lastDay) {
+        return new Date(adj.getTime()-86400000); 
+    }
+    if (d.getUTCDate()!=adj.getUTCDate()) {
+        adj.setUTCDate(0)
+    }
+    return adj;
+}
+
+/**
+ * ISOWEEK(Date)
+ * @param {Date} d - the date
+ * @param {NUmber} - the ISO Week of the date
+ */
+FormulaEngine.isoweek = function(date) {
+    if (!date) return date;
+    var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    var dayNum = d.getUTCDay() || 7
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+    var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+    return Math.ceil((((d - yearStart)/86400000) + 1)/7);
+}
+
+/**
+ * ISOYEAR(Date)
+ * @param {Date} date - the date
+ * @param {NUmber} - the ISO YEAR of the date
+ */
+FormulaEngine.isoyear = function(date) {
+    if (!date) return date;
+    var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    var dayNum = d.getUTCDay() || 7
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+    var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+    return yearStart.getUTCFullYear();
+}
+
+/**
+ * DAYOFYEAR(Date)
+ * @param {Date} d - the date
+ * @param {Number} - the day of the year
+ */
+FormulaEngine.dayofyear = function(date) {
+    if (!date) return date;
+    var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+    var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+    return Math.ceil((1+(d - yearStart))/86400000);
+}
+
+
+/**
+ * INITCAP(String) - Capitalize all the "first" characters in words
+ * @param {String} str - the string 
+ * @returns {String} - the string with the first characters of words converted to uppercase
+ */
+FormulaEngine.initcap = function(str) {
+    if (!str) return str;
+    // Init cap... Normalize and use unicode to match postgres/oracle behavior
+    return str.toLowerCase().replace(/(?:^|[^\p{Ll}\p{Lm}\p{Lu}\p{N}])[\p{Ll}]/gu, function (m) {return m.toUpperCase();});
+}
+
+/**
+ * LPAD(String,Number[,String]) - Pad the left side of the string with the pad repeated.
+ * @param {String} str - the string to pad on the left
+ * @param {Number} len - length to pad
+ * @param {String} pad - the optional string to pad.
+ */    
+FormulaEngine.lpad = function(str,len,pad) {
+    return !str||!len||len<1?null:(len<=str.length?str.substring(0,len):((Array(256).join(pad)+'').substring(0,len-str.length))+str);
+}
+    
+/**
+ * FORMATDURATION() - Format the duration as defined by the unix epoch as hh:mm:ss or ddd:hh:mm:ss.
+ * @param {Date} s - the date to format
+ * @param {boolean} includeDays - whether to include days in the display
+ */
+FormulaEngine.formatduration = function(s, includeDays) {
+    if (isNaN(s)) { // invalid date
+        return null; 
+    }
+    if (includeDays) {
+        return Math.trunc(s/86400)+':'+(''+Math.trunc(s/3600)%24).padStart(2,'0')+':'+(''+Math.trunc(s/60)%60).padStart(2,'0')+':'+(''+Math.trunc(s%60)).padStart(2,'0');
+    } else {
+        return (''+Math.trunc(s/3600)).padStart(2,'0')+':'+(''+Math.trunc(s/60)%60).padStart(2,'0')+':'+(''+Math.trunc(s%60)).padStart(2,'0');
+    }
+}   
+
+if (typeof module != 'undefined' && module.exports) {
+   module.exports = FormulaEngine;
+}
+/** version: 0.3.0 */

--- a/impl/src/main/resources/com/force/formula/formulaEngine.mjs
+++ b/impl/src/main/resources/com/force/formula/formulaEngine.mjs
@@ -1,0 +1,174 @@
+/**
+ * Copyright (C) 2019-2022 salesforce.com, inc.
+ * Formula Engine Client Side Library
+ *
+ * import { FormulaEngine as $F } from '...'
+ */
+export class FormulaEngine {
+    /*
+     * Utility functions for the Client Formula Engine
+     * Equivalent to Oracle's NVL function.
+     * @param {Object} value - the value to check
+     * @param {Object} ifNull - returned if value is null or undefined
+     * @returns {Object} value if value is not null or undefined, otherwise ifNull
+     */
+    nvl(value, ifNull) {
+        return value !== null && value !== undefined ? value : ifNull;
+    }
+    /*
+     * Utility functions for the Client Formula Engine - Equivalent of AuraUtil.js
+     * Null Or Empty - Return value if value is not null and not an empty string, ifNull otherwise.
+     * @param {Object} value - the value to check
+     * @param {Object} ifNull - returned if value is null or undefined or empty
+     * @returns {Object} value if value is not null or undefined, otherwise ifNull
+     */
+    noe(value, ifNull) {
+        if (value === undefined || value === null || value === '') {
+            return ifNull;
+        }
+        return value;
+    }
+    /**
+     * Checks all tests and returns true if any are null or undefined.
+     * @param {List} tests - the list of values to check
+     * @returns {boolean} true if any value in tests is null or undefined
+     */
+    anl(tests) {
+        return Array.isArray(tests) && tests.some(val => val === null || val === undefined);
+    }
+    
+    /**
+     * Return the value as a string, while leaving null and undefined alone.
+     * @param {Object} value - the object to stringify
+     * @returns {String} a stringified version of value
+     */
+    tostr(value) {
+        if(value===undefined||value===null||value==='') {
+            return value;
+        }        
+        return String(value)
+    }
+    
+    /**
+     * Chrome, Node & GraalJS have lenient date parsing for 'YYYY-MM-DD HH:MM:SS'.  Others require ecmascript ISO formatting only (with T & Z).
+     * try both
+     * @param {String} value - a string value that is similar to an ISO date format.
+     * @returns {Date} - a date object that may be invalid
+     */
+    parseDateTime(value) {
+        if (value===undefined||value===null||value==='') {
+            return null;
+        }
+        var d = new Date(value.trim().replace(' ','T')+'Z'); 
+        return isNaN(d) ? new Date(value.trim() + ' GMT') : d;
+    }
+    
+    /**
+     * ADDMONTHS()
+     * Note, Javascript setMonths has strange behavior since it'll make January 30th + 1 month may be March.  
+     * And last day needs to remain last day to match oracle.
+     * So if it's the last day of the month, we add one to the day and add the month, then remove the day.  
+     * Otherwise we use the "set Date to 0 to be last day of previous month" javascript behavior 
+     * so Jan 30 + 1 month will be Feb 28 in a non-leap year 
+     * @param {Date} d - a date to add months to
+     * @param {Number} months - the number of months to add to the date
+     * @returns {Date} - the date with the numver of months added
+     */
+    addmonths(d,months) {
+        if (d==null||d==null) return null;
+        if (!months) return d;
+        var lastDay=d.getUTCDay()==(new Date(Date.UTC(d.getUTCFullYear(),d.getUTCMonth()+1,0))).getUTCDay();
+        var adj=new Date(d.getTime()+(lastDay?86400000:0));
+        adj.setUTCMonth(adj.getUTCMonth()+Math.trunc(months));
+        if (lastDay) {
+            return new Date(adj.getTime()-86400000); 
+        }
+        if (d.getUTCDate()!=adj.getUTCDate()) {
+            adj.setUTCDate(0)
+        }
+        return adj;
+    }
+    
+    /**
+     * ISOWEEK(Date)
+     * @param {Date} d - the date
+     * @param {NUmber} - the ISO Week of the date
+     */
+    isoweek(date) {
+        if (!date) return date;
+        var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        var dayNum = d.getUTCDay() || 7
+        d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+        var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+        return Math.ceil((((d - yearStart)/86400000) + 1)/7);
+    }
+    
+    /**
+     * ISOYEAR(Date)
+     * @param {Date} date - the date
+     * @param {NUmber} - the ISO YEAR of the date
+     */
+    isoyear(date) {
+        if (!date) return date;
+        var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        var dayNum = d.getUTCDay() || 7
+        d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+        var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+        return yearStart.getUTCFullYear();
+    }
+    
+    /**
+     * DAYOFYEAR(Date)
+     * @param {Date} d - the date
+     * @param {Number} - the day of the year
+     */
+    dayofyear(date) {
+        if (!date) return date;
+        var d = new Date(Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()));
+        var yearStart = new Date(Date.UTC(d.getUTCFullYear(),0,1));
+        return Math.ceil((1+(d - yearStart))/86400000);
+    }
+    
+    
+    /**
+     * INITCAP(String) - Capitalize all the "first" characters in words
+     * @param {String} str - the string 
+     * @returns {String} - the string with the first characters of words converted to uppercase
+     */
+    initcap(str) {
+        if (!str) return str;
+        // Init cap... Normalize and use unicode to match postgres/oracle behavior
+        return str.toLowerCase().replace(/(?:^|[^\p{Ll}\p{Lm}\p{Lu}\p{N}])[\p{Ll}]/gu, function (m) {return m.toUpperCase();});
+    }
+
+    /**
+     * LPAD(String,Number[,String]) - Pad the left side of the string with the pad repeated.
+     * @param {String} str - the string to pad on the left
+     * @param {Number} len - length to pad
+     * @param {String} pad - the optional string to pad.
+     */    
+    lpad(str,len,pad) {
+        return !str||!len||len<1?null:(len<=str.length?str.substring(0,len):((Array(256).join(pad)+'').substring(0,len-str.length))+str);
+    }
+    
+        
+    /**
+     * FORMATDURATION() - Format the duration as defined by the unix epoch as hh:mm:ss or ddd:hh:mm:ss.
+     * @param {Date} s - the date to format
+     * @param {boolean} includeDays - whether to include days in the display
+     */
+    formatduration(s, includeDays) {
+        if (isNaN(s)) { // invalid date
+            return null; 
+        }
+        if (includeDays) {
+            return Math.trunc(s/86400)+':'+(''+Math.trunc(s/3600)%24).padStart(2,'0')+':'+(''+Math.trunc(s/60)%60).padStart(2,'0')+':'+(''+Math.trunc(s%60)).padStart(2,'0');
+        } else {
+            return (''+Math.trunc(s/3600)).padStart(2,'0')+':'+(''+Math.trunc(s/60)%60).padStart(2,'0')+':'+(''+Math.trunc(s%60)).padStart(2,'0');
+        }
+    }   
+    
+    
+    // TODO: Put Decimal and jsonpath here...
+};
+/** version: 0.3.0 */

--- a/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
+++ b/impl/src/test/java/com/force/formula/commands/BuiltinFunctionsJsTest.java
@@ -9,6 +9,8 @@ import java.util.TimeZone;
 
 import com.force.formula.FormulaDataType;
 import com.force.formula.FormulaException;
+import com.force.formula.FormulaRuntimeContext;
+import com.force.formula.MockFormulaContext;
 import com.force.formula.MockFormulaType;
 
 /**
@@ -50,4 +52,17 @@ public class BuiltinFunctionsJsTest extends BuiltinFunctionsTest {
     @Override
     public void testRPAD() throws Exception {}
 
+    @Override
+    protected FormulaRuntimeContext setupMockContext(FormulaDataType columnType) {
+        return new MockFormulaContext(getFormulaType(), columnType) {
+
+            @Override
+            public String getJsEngMod() {
+                // Use FormulaEngine to make sure it works with the "default".  Use $F in the gold files for brevity
+                return "FormulaEngine";
+            }
+            
+        };
+    }
+    
 }

--- a/test-utils/src/main/java/com/force/formula/impl/FormulaTestUtils.java
+++ b/test-utils/src/main/java/com/force/formula/impl/FormulaTestUtils.java
@@ -460,10 +460,6 @@ public class FormulaTestUtils {
      *            The string to split
      * @param delimiter
      *            The delimiter to split the string using
-     * @param expectedSize
-     *            The expected number of elements in the output list. If you don't know, or if it could be arbitrarily
-     *            large, and if you will only access the returned list sequentially with an iterator, then use 0 to tell
-     *            this method to use a LinkedList
      * @return String list or, if str was null, then null
      */
     public static List<String> splitSimpleWithQuoteAndEsc(String str, char delimiter) {

--- a/test-utils/src/main/java/com/force/formula/sql/AbstractDbTester.java
+++ b/test-utils/src/main/java/com/force/formula/sql/AbstractDbTester.java
@@ -275,8 +275,10 @@ public abstract class AbstractDbTester implements DbTester {
 	
 	/**
 	 * @return the value to use as a literal sql value for the display field.
+	 * @param pstmt the prepared statement to bind
 	 * @param df the display field
 	 * @param value the value from the MapEntityObject
+	 * @param position the numeric position to bind
 	 */
 	protected void bindSqlValue(PreparedStatement pstmt, DisplayField df, Object value, int position) throws SQLException {
 		switch ((MockFormulaDataType) df.getFormulaFieldInfo().getDataType()) {
@@ -360,7 +362,7 @@ public abstract class AbstractDbTester implements DbTester {
 	 * for comparing with Java and Javascript evaluation
 	 * @param rset the result set already nexted to the first row, with the result in column 1
 	 * @param formulaContext the formula contex used to evaluate
-	 * @param formula the formula that generated the sql (with the result passed through {@link #fixSqlFormat(String, Formula)}
+	 * @param formula the formula that generated the sql (with the result passed through {@link #fixSqlFormat(FormulaContext, String, Formula)}
 	 * @return a String formatted, or null if the object is null
 	 * @throws SQLException if there was a SQL exception
 	 */

--- a/test-utils/src/main/java/com/force/formula/template/commands/MockRenamingProvider.java
+++ b/test-utils/src/main/java/com/force/formula/template/commands/MockRenamingProvider.java
@@ -20,7 +20,7 @@ import com.google.common.collect.ImmutableMap;
  * RenamingProvider curProvider = RenamingProviderFactory.get().getProvider();
  * try {
  *     MockRenamingProvider newProvider = new MockRenamingProvider(makeEnglishNoun("account", NounType.ENTITY,
- *             LanguageStartsWith.CONSONANT, "Client or Person", "Clients & People"));
+ *             LanguageStartsWith.CONSONANT, "Client or Person", "Clients &amp; People"));
  * } finally {
  *     RenamingProviderFactory.get().setProvider(curProvider);
  * }


### PR DESCRIPTION
Have a formulaEngine.mjs module and a .js version that's easier to parameterize. Have FormulaContext allow parameterization of the JsModule and test it in BuiltInFunctions Fix a few javadoc compile errors