### PR TITLE
[WIP] Require a cast to timestamp in postgres/sdb

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/sql/FormulaPostgreSQLHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/sql/FormulaPostgreSQLHooks.java
@@ -86,6 +86,15 @@ public interface FormulaPostgreSQLHooks extends FormulaSqlHooks {
     default String sqlToChar() {
 		return "CAST(%s AS TEXT)";
     }
+
+    /**
+     * @return the format for String.format for converting from a datetime value to a string YYYY-MM-DD HH24:MI:SS,
+     * require a cast to ::timestamp in postgres
+     */
+    @Override
+    default String sqlToCharTimestamp() {
+        return "TO_CHAR((%s)::timestamp(0), 'YYYY-MM-DD HH24:MI:SS')";
+    }
     
     /**
      * @return the string to use for TO_TIMESTAMP to get seconds.microseconds.  It's a subtle difference

--- a/impl/src/test/goldfiles/FormulaFields/testDateTimeText.xml
+++ b/impl/src/test/goldfiles/FormulaFields/testDateTimeText.xml
@@ -2,11 +2,11 @@
 <testCase name="testDateTimeText">
    <testInstance formula="Text(customdatetime1__c)" returntype="Text">
     <SqlOutput nullAsNull="true">
-       <Sql>(CONCAT(TO_CHAR($!s0s!$.customdatetime1__c, 'YYYY-MM-DD HH24:MI:SS'), 'Z' ))</Sql>
+       <Sql>(CONCAT(TO_CHAR(($!s0s!$.customdatetime1__c)::timestamp(0), 'YYYY-MM-DD HH24:MI:SS'), 'Z' ))</Sql>
        <Guard>null</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="false">
-       <Sql>(CONCAT(TO_CHAR($!s0s!$.customdatetime1__c, 'YYYY-MM-DD HH24:MI:SS'), 'Z' ))</Sql>
+       <Sql>(CONCAT(TO_CHAR(($!s0s!$.customdatetime1__c)::timestamp(0), 'YYYY-MM-DD HH24:MI:SS'), 'Z' ))</Sql>
        <Guard>null</Guard>
     </SqlOutput>
     <JsOutput highPrec="true" nullAsNull="false">(($F.anl([context.record.customdatetime1__c])?null:$F.parseDateTime(context.record.customdatetime1__c))!=null)?((($F.anl([context.record.customdatetime1__c])?null:$F.parseDateTime(context.record.customdatetime1__c)).toISOString().replace('T',' ').substring(0,19)+'Z')):null</JsOutput>


### PR DESCRIPTION
Making sqlToCharTimestamp() return "TO_CHAR((%s)::timestamp(0), 'YYYY-MM-DD HH24:MI:SS')" for postgres/sdb. With this, the data type of (%s) won't be unknown after the cast.