### PR TITLE
@W-13161871 add guard for CaseSafeId #119

### DIFF
--- a/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
+++ b/impl/src/main/java/com/force/formula/impl/FormulaValidationHooks.java
@@ -670,4 +670,13 @@ public interface FormulaValidationHooks extends FormulaEngineHooks {
         // retrun OptimizedURLEncoder.encode(TextUtil.replaceIncompatibleCharacters(entry.toString(), urlEncoding), urlEncoding);
         return URLEncoder.encode(string, urlEncoding);
     }
+
+    /**
+     * When TRUE, CaseSafeId will use sql function to convert an ID, otherwise it will use inline sql to convert an ID.
+     *
+     * Default false
+     */
+    default boolean shouldOptimizeCaseSafeIdFunc() {
+        return false;
+    }
 }


### PR DESCRIPTION
Add shouldOptimizeCaseSafeIdFunc() to here to avoid this: 

Cause0: java.lang.NoSuchMethodError: 'boolean com.force.formula.impl.FormulaValidationHooks.shouldOptimizeCaseSafeIdFunc()'
 Cause0-StackTrace:
        at com.force.formula.sfdc.commands.FunctionCaseSafeId.getSQL(FunctionCaseSafeId.java:51)
        at com.force.formula.commands.FormulaCommandInfoImpl.getSQL(FormulaCommandInfoImpl.java:224)
        at com.force.formula.impl.BaseFormulaInfoImpl.visitPostorder(BaseFormulaInfoImpl.java:697)
        at com.force.formula.impl.BaseFormulaInfoImpl.<init>(BaseFormulaInfoImpl.java:145)
        at common.formula.FormulaInfoImpl.<init>(FormulaInfoImpl.java:61)
        at common.formula.FormulaCoreFactory.create(FormulaCoreFactory.java:71)
        at com.force.formula.impl.FormulaInfoFactory.create(FormulaInfoFactory.java:50)
        at common.udd.impl.SimpleCustomFieldInfoImpl.getFormulaInfo(SimpleCustomFieldInfoImpl.java:401)
        at common.udd.impl.SimpleCustomFieldInfoImpl.getFormula(SimpleCustomFieldInfoImpl.java:421)
        at common.udd.object.SingleColField.getFormulaValue(SingleColField.java:605)
