### PR TITLE
@W-13596942 fix for readonly gold files in core

### DIFF
--- a/test-utils/src/main/java/com/force/formula/impl/BaseFormulaGenericTests.java
+++ b/test-utils/src/main/java/com/force/formula/impl/BaseFormulaGenericTests.java
@@ -410,6 +410,7 @@ abstract public class BaseFormulaGenericTests extends TestSuite {
 			try {
 				File f = new File(getDirectory() + "/" + testCase.getName() + ".xml");
 				f.getParentFile().mkdirs();
+				f.setWritable(true);
 				
 				byte[] results = xml.toByteArray();
 				if (f.exists()) {
@@ -421,6 +422,7 @@ abstract public class BaseFormulaGenericTests extends TestSuite {
 								.disableHtmlEscaping().serializeNulls().create();
 				File jsonFile = new File(getJsonDirectory() + "/" + testCase.getName() + ".json");
 				jsonFile.getParentFile().mkdirs();
+				jsonFile.setWritable(true);
 				FileWriter fileWriter = new FileWriter(jsonFile);
 				gson.toJson(jestDataModel, fileWriter);
 				fileWriter.flush();


### PR DESCRIPTION
Gold files in core are read only. This is to fix java.io.FileNotFoundException: goldfiles/FormulaFields/testBR.xml (Permission denied) in core. 