### PR TITLE
@W-14371508 fix: JS Substitute function to replace all matches

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
@@ -36,7 +36,7 @@ public class FunctionSubstitute extends FormulaCommandInfoImpl {
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
         /**
-         * JS replaceAll matively returns the original string if arg[1] is null and replaces with null if arg[2] is null
+         * JS replaceAll natively returns the original string if arg[1] is null and replaces with null if arg[2] is null
          * However, the SQL and Java implementation returns null if arg[1] is null and replaces with "" if arg[2] is null
          * To align with SQL and Java implementation, we are putting JS guards on arg[1] and arg[2] of substitute function
          * If arg[1] is null return null, else if arg[2] is null then consider arg[2] as "" and call replaceAll(arg[1],"")

--- a/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
@@ -42,9 +42,9 @@ public class FunctionSubstitute extends FormulaCommandInfoImpl {
          * If arg[1] is null return null, else if arg[2] is null then consider arg[2] as "" and call replaceAll(arg[1],"")
          * If arg[1] and arg[2] are not null, then call replaceAll(arg[1],arg[2])
          * E.g.
-         *     SUBSTITUTE("Hello; Text;", null, ",") reutns null
-         *     SUBSTITUTE("Hello; Text;", ";", null) reutns "Hello Text"
-         *     SUBSTITUTE("Hello; Text;", ";", ',') reutns "Hello, Text,"
+         *     SUBSTITUTE("Hello; Text;", null, ",") returns null
+         *     SUBSTITUTE("Hello; Text;", ";", null) returns "Hello Text"
+         *     SUBSTITUTE("Hello; Text;", ";", ',') returns "Hello, Text,"
          */
         return JsValue.generate("(" + args[1] + " === null ? null : (" + args[2] + " === null ? "
                         + args[0] + ".replaceAll(" + args[1] + ",\"\") :"

--- a/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionSubstitute.java
@@ -35,7 +35,21 @@ public class FunctionSubstitute extends FormulaCommandInfoImpl {
     
     @Override
     public JsValue getJavascript(FormulaAST node, FormulaContext context, JsValue[] args) throws FormulaException {
-        return JsValue.generate(args[0] + ".replace(" + args[1] + "," + args[2] + ")", args, false, args[0]); // TODO: Ignore other guards?
+        /**
+         * JS replaceAll matively returns the original string if arg[1] is null and replaces with null if arg[2] is null
+         * However, the SQL and Java implementation returns null if arg[1] is null and replaces with "" if arg[2] is null
+         * To align with SQL and Java implementation, we are putting JS guards on arg[1] and arg[2] of substitute function
+         * If arg[1] is null return null, else if arg[2] is null then consider arg[2] as "" and call replaceAll(arg[1],"")
+         * If arg[1] and arg[2] are not null, then call replaceAll(arg[1],arg[2])
+         * E.g.
+         *     SUBSTITUTE("Hello; Text;", null, ",") reutns null
+         *     SUBSTITUTE("Hello; Text;", ";", null) reutns "Hello Text"
+         *     SUBSTITUTE("Hello; Text;", ";", ',') reutns "Hello, Text,"
+         */
+        return JsValue.generate("(" + args[1] + " === null ? null : (" + args[2] + " === null ? "
+                        + args[0] + ".replaceAll(" + args[1] + ",\"\") :"
+                        + args[0] + ".replaceAll(" + args[1] + "," + args[2] + ")))",
+                args, false, args[0]);
     }
 
 }

--- a/impl/src/test/goldfiles/FormulaFields/v2/postgres/testSimpleSubstitute.xml
+++ b/impl/src/test/goldfiles/FormulaFields/v2/postgres/testSimpleSubstitute.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <testCase name="testSimpleSubstitute">
-    <JsOutput highPrec="true" nullAsNull="false">(context.record.customtext1__c!=null)?(context.record.customtext1__c.replace(context.record.customtext2__c,context.record.customtext3__c)):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="false">(context.record.customtext1__c!=null)?(context.record.customtext1__c.replace(context.record.customtext2__c,context.record.customtext3__c)):null</JsOutput>
-    <JsOutput highPrec="false" nullAsNull="true">(context.record.customtext1__c!=null)?(context.record.customtext1__c.replace(context.record.customtext2__c,context.record.customtext3__c)):null</JsOutput>
-    <JsOutput highPrec="true" nullAsNull="true">(context.record.customtext1__c!=null)?(context.record.customtext1__c.replace(context.record.customtext2__c,context.record.customtext3__c)):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="false">(context.record.customtext1__c!=null)?((context.record.customtext2__c === null ? null : (context.record.customtext3__c === null ? context.record.customtext1__c.replaceAll(context.record.customtext2__c,&quot;&quot;) :context.record.customtext1__c.replaceAll(context.record.customtext2__c,context.record.customtext3__c)))):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="false">(context.record.customtext1__c!=null)?((context.record.customtext2__c === null ? null : (context.record.customtext3__c === null ? context.record.customtext1__c.replaceAll(context.record.customtext2__c,&quot;&quot;) :context.record.customtext1__c.replaceAll(context.record.customtext2__c,context.record.customtext3__c)))):null</JsOutput>
+    <JsOutput highPrec="false" nullAsNull="true">(context.record.customtext1__c!=null)?((context.record.customtext2__c === null ? null : (context.record.customtext3__c === null ? context.record.customtext1__c.replaceAll(context.record.customtext2__c,&quot;&quot;) :context.record.customtext1__c.replaceAll(context.record.customtext2__c,context.record.customtext3__c)))):null</JsOutput>
+    <JsOutput highPrec="true" nullAsNull="true">(context.record.customtext1__c!=null)?((context.record.customtext2__c === null ? null : (context.record.customtext3__c === null ? context.record.customtext1__c.replaceAll(context.record.customtext2__c,&quot;&quot;) :context.record.customtext1__c.replaceAll(context.record.customtext2__c,context.record.customtext3__c)))):null</JsOutput>
     <SqlOutput nullAsNull="false">
        <Sql>REPLACE($!s0s!$.customtext1__c, $!s0s!$.customtext2__c, $!s0s!$.customtext3__c)</Sql>
        <Guard>null</Guard>

--- a/impl/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/impl/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -14191,6 +14191,87 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match,
+					No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
     </testcase>
 <!--    <testcase testName="testTextNum"
               fieldName="testTextNum"


### PR DESCRIPTION
1. Fixed Substitute function to replace all matching keywords
2. Use replaceAll instead of replace in getJavaScript()
3. Aligned the implementation with formula and sql based executors
4. Added test cases. 