### PR TITLE
@W-14371508 fix: JS Substitute DB tests for parity

### DIFF
--- a/google-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/google-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7921,6 +7921,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
     <testcase testName="testTextNum"
               fieldName="testTextNum"

--- a/h2-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/h2-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7960,6 +7960,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
    <testcase testName="testTextNum"
              fieldName="testTextNum"

--- a/mysql-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/mysql-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7954,6 +7954,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
    <testcase testName="testTextNum"
              fieldName="testTextNum"

--- a/oracle-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/oracle-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -8058,6 +8058,41 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
    <testcase testName="testTextNum"
              fieldName="testTextNum"

--- a/presto-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/presto-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7859,6 +7859,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
    <testcase testName="testTextNum"
              fieldName="testTextNum"

--- a/sqlite-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/sqlite-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7932,6 +7932,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
    </testcase>
    <testcase testName="testTextNum"
              fieldName="testTextNum"

--- a/sqlserver-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
+++ b/sqlserver-test/src/test/resources/com/force/formula/impl/formulaTestV2.xml
@@ -7954,6 +7954,51 @@
 					Platinum File,
 					Platinum File,
 					Platinum File"/>
+        <testData input="No match,First,Second"
+                  expectedOutput="No match,
+					No match,
+					No match,
+					No match"/>
+        <testData input="Salesforce,,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input=",old,new"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Golden File,, Platinum"
+                  expectedOutput="null,
+					null,
+					null,
+					null"/>
+        <testData input="Replace Space, ,No"
+                  expectedOutput="ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace,
+					ReplaceNoSpace"/>
+        <testData input="Replace All x x x,x,z"
+                  expectedOutput="Replace All z z z,
+					Replace All z z z,
+					Replace All z z z,
+					Replace All z z z"/>
+        <testData input="Replace All xxx,x,z"
+                  expectedOutput="Replace All zzz,
+					Replace All zzz,
+					Replace All zzz,
+					Replace All zzz"/>
     </testcase>
     <testcase testName="testTextNum"
               fieldName="testTextNum"


### PR DESCRIPTION
Add missing DB tests for the Substitute function to bring it to parity with Postgres tests including the JS path 