### PR TITLE
@W-17649725 Removing nonFlowOnly from the context of TIMENOW and TIMEVALUE

### DIFF
--- a/impl/src/main/java/com/force/formula/commands/FunctionTimeNow.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionTimeNow.java
@@ -16,7 +16,7 @@ import com.force.i18n.BaseLocalizer;
  * @author p
  * @since 140
  */
-@AllowedContext(section=SelectorSection.DATE_TIME, nonFlowOnly=true)
+@AllowedContext(section=SelectorSection.DATE_TIME)
 public class FunctionTimeNow extends FormulaCommandInfoImpl {
 
     public FunctionTimeNow() {

--- a/impl/src/main/java/com/force/formula/commands/FunctionTimeValue.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionTimeValue.java
@@ -34,7 +34,7 @@ import com.force.i18n.BaseLocalizer;
  * @author pjain
  * @since 208
  */
-@AllowedContext(section=SelectorSection.DATE_TIME, nonFlowOnly=true, isOffline=true)
+@AllowedContext(section=SelectorSection.DATE_TIME, isOffline=true)
 public class FunctionTimeValue extends FormulaCommandInfoImpl implements FormulaCommandValidator {
 
     protected final static String JS_FORMAT_TEMPLATE = "new Date(new Date(%s).setUTCFullYear(1970,0,1))";


### PR DESCRIPTION
@W-17649725 This PR contains the changes done on the Formula Engine side to add Time data type support to the Formula Builder of Flow Builder. FunctionTimeValue and FunctionTimeNow are two formula functions which perform Time related operations. These two functions currently have the nonFlowOnly property in their context set to true and the removal of this property is essential for Flow Builder to be able consume these two formulas.