### PR TITLE
@W-17066806 add guard to CHR function

### DIFF
--- a/docs/coverage/pom.xml
+++ b/docs/coverage/pom.xml
@@ -57,12 +57,12 @@
     <profile>
       <id>db-tests</id>
       <dependencies>
+        <!-- Rely on core for tests of oracle
         <dependency>
           <groupId>com.salesforce.formula</groupId>
           <artifactId>formula-engine-oracle-test</artifactId>
           <version>${project.version}</version>
         </dependency>
-        <!--
         <dependency>
           <groupId>com.salesforce.formula</groupId>
           <artifactId>formula-engine-sqlserver-test</artifactId>

--- a/impl/src/main/java/com/force/formula/commands/FunctionChr.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionChr.java
@@ -34,7 +34,7 @@ public class FunctionChr extends FormulaCommandInfoImpl {
 
     @Override
     public SQLPair getSQL(FormulaAST node, FormulaContext context, String[] args, String[] guards, TableAliasRegistry registry) {
-        String guard = SQLPair.generateGuard(guards, args[0] + "<1");
+        String guard = SQLPair.generateGuard(guards, args[0] + "<1 OR " + args[0] + ">1114111");
         return new SQLPair(String.format(getSqlHooks(context).sqlChr(), args[0]), guard);
     }
 

--- a/impl/src/test/goldfiles/FormulaFields/v2/postgres/testChr.xml
+++ b/impl/src/test/goldfiles/FormulaFields/v2/postgres/testChr.xml
@@ -6,10 +6,10 @@
     <JsOutput highPrec="true" nullAsNull="true">(context.record.customnumber__c&amp;&amp;context.record.customnumber__c.toNumber()&gt;0?String.fromCodePoint(Math.trunc(context.record.customnumber__c.toNumber())):null)</JsOutput>
     <SqlOutput nullAsNull="false">
        <Sql>CHR(TRUNC(COALESCE($!s0s!$.customnumber__c, 0))::integer)</Sql>
-       <Guard>COALESCE($!s0s!$.customnumber__c, 0)&lt;1</Guard>
+       <Guard>COALESCE($!s0s!$.customnumber__c, 0)&lt;1 OR COALESCE($!s0s!$.customnumber__c, 0)&gt;1114111</Guard>
     </SqlOutput>
     <SqlOutput nullAsNull="true">
        <Sql>CHR(TRUNC($!s0s!$.customnumber__c)::integer)</Sql>
-       <Guard>$!s0s!$.customnumber__c&lt;1</Guard>
+       <Guard>$!s0s!$.customnumber__c&lt;1 OR $!s0s!$.customnumber__c&gt;1114111</Guard>
     </SqlOutput>
 </testCase>

--- a/pom.xml
+++ b/pom.xml
@@ -537,7 +537,8 @@
         <module>api</module>
         <module>impl</module>
         <module>test-utils</module>
-        <module>oracle-test</module>
+        <!-- Oracle tests run from within core -->
+        <!--<module>oracle-test</module>-->
         <!-- <module>mysql-test</module> -->
         <!-- MYSQL tests having issues in handling regular expressions, so excluding these tests from maven build process-->
 	<!-- These tests can be executed by using the "mysql" profile e.g. `mvn -P mysql clean verify -B` -->


### PR DESCRIPTION
Added guard for CHR function so that inputs larger than 1114111 cause error.

Also, commented out some oracle tests, per our goal of focusing this repo on postgres.