### PR TITLE
@W-14808875 - allow ISNULL to work with booleans when used in clientside JavaScript

### DIFF
--- a/api/src/main/java/com/force/formula/FormulaContext.java
+++ b/api/src/main/java/com/force/formula/FormulaContext.java
@@ -27,6 +27,8 @@ public interface FormulaContext extends Tokenizer {
     String HIGHPRECISION_JS = "com.force.formula.impl.HIGHPRECISION_JS";
     /** See {@link #jsDatesAreStrings} */
     String JS_DATES_ARE_STRINGS = "com.force.formula.impl.JS_DATES_ARE_STRINGS";
+    /** See {@link #allowNullableBooleansInJs} */
+    String ALLOW_NULLABLE_BOOLEANS_IN_JS = "com.force.formula.impl.ALLOW_NULLABLE_BOOLEANS_IN_JS";
 
     String IS_CREATE_OR_EDIT_FORMULA = "com.force.formula.impl.IS_CREATE_OR_EDIT_FORMULA";
     String FORCE_DISABLED = "com.force.formula.impl.FORCE_DISABLED";
@@ -187,6 +189,15 @@ public interface FormulaContext extends Tokenizer {
     default boolean jsDatesAreStrings() {
         Boolean val = getProperty(JS_DATES_ARE_STRINGS);
         return val == null ? true : val;
+    }
+
+    /**
+     * @return <code>true</code> when allowing boolean fields in JS to be compared to null.
+     * Otherwise a boolean can only be <code>true</code> or <code>false</code>.
+     */
+    default boolean allowNullableBooleansInJs() {
+        Boolean val = getProperty(ALLOW_NULLABLE_BOOLEANS_IN_JS);
+        return val == null ? false : val;
     }
     
     /**

--- a/api/src/test/java/com/force/formula/util/BaseCompositeFormulaContextTest.java
+++ b/api/src/test/java/com/force/formula/util/BaseCompositeFormulaContextTest.java
@@ -72,6 +72,7 @@ public class BaseCompositeFormulaContextTest {
 		Assert.assertEquals("name", test.getJavascriptReference());
 		Assert.assertEquals(null, test.getSqlStyle());
 		Assert.assertTrue(test.jsDatesAreStrings());
+		Assert.assertFalse(test.allowNullableBooleansInJs());
 		Assert.assertFalse(test.useHighPrecisionJs());
 		Assert.assertFalse(test.isCheckingSqlLengthLimit());
 		Assert.assertFalse(test.isNew());

--- a/impl/src/main/java/com/force/formula/commands/FunctionIsNull.java
+++ b/impl/src/main/java/com/force/formula/commands/FunctionIsNull.java
@@ -90,7 +90,8 @@ public class FunctionIsNull extends FormulaCommandInfoImpl implements FormulaCom
 
         FormulaAST arg = (FormulaAST)node.getFirstChild();
         Type argDataType = arg.getDataType();
-        if (argDataType == Boolean.class)
+        boolean allowNullableBooleansInJs = context.allowNullableBooleansInJs();
+        if (argDataType == Boolean.class && !allowNullableBooleansInJs)
             throw new IllegalArgumentTypeException(node.getText());
         return Boolean.class;
     }


### PR DESCRIPTION
This is needed in Screen Flows for checkbox inputs which can be hidden. If a field is hidden by rules then it's value should be null. This is true for all fields, but unfortunately checkboxes are immediately registed as booleans and therefore due to the formula engine restricting null checks on booleans we have a number of bugs that come up.

This fix allows booleans to be null checked when the allowNullableBooleansInJs flag is set to true.